### PR TITLE
perf(point_and_click): check mouse down before bounds checking.

### DIFF
--- a/scripts/scr_hit/scr_hit.gml
+++ b/scripts/scr_hit/scr_hit.gml
@@ -16,22 +16,25 @@ function scr_hit(x1=0, y1=0, x2=0, y2=0) {
 /// @description Returns true if left mouse button was clicked on the desired rectangle area.
 /// @param {array} rect x1, y1, x2, y2 array.
 /// @returns {bool}
-function point_and_click(rect){
+function point_and_click(rect) {
 	var controller_exist = instance_exists(obj_controller);
 	var click_check = false;
 	var mouse_consts = return_mouse_consts();
+	var mouse_clicked = event_number==ev_gui ? device_mouse_check_button_pressed(0,mb_left) : mouse_check_button_pressed(mb_left);
 
-	if (controller_exist && obj_controller.cooldown > 0) {
+	if (!mouse_clicked) {
 		return false;
 	}
 
-	if (point_in_rectangle(mouse_consts[0], mouse_consts[1], rect[0], rect[1],rect[2], rect[3])){
-		click_check = event_number==ev_gui ? device_mouse_check_button_pressed(0,mb_left) : mouse_check_button_pressed(mb_left);
-		if (controller_exist && click_check) {
-			obj_controller.cooldown = 8000;
-		}
+	if (controller_exist && obj_controller.cooldown > 0) {
+		show_debug_message("point_and_click: ignored click for cooldown, " + string(obj_controller.cooldown) + " steps remaining");
+		return false;
 	}
 
+	var click_check = point_in_rectangle(mouse_consts[0], mouse_consts[1], rect[0], rect[1],rect[2], rect[3]);
+	if (controller_exist && click_check) {
+		obj_controller.cooldown = 8000;
+	}
 	return click_check;
 }
 


### PR DESCRIPTION
Optimizes the `point_and_click` function by checking if the mouse is clicked before performing boundary checks. This prevents unnecessary calculations when no click has occurred.

- Moved the mouse click check ahead of the rectangle boundary check.
- Added a debug message for cases where clicks are ignored due to an active cooldown.

This change reduces redundant operations and improves performance by avoiding bounds checking when no click is detected.
