### PR TITLE
fix(obj_ini): correct vehicle index in veh_lid initialization

### DIFF
--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -46,7 +46,7 @@ repeat(200){i+=1;
     artifact_struct[i] =  new ArtifactStruct(i);    
 }
 
-var i=-1,v=0;
+var i=-1;
 repeat(210){i+=1;
     ship[i]="";
     ship_uid[i]=0;
@@ -94,13 +94,11 @@ repeat(11){
         veh_hp[company,v]=100;
         veh_chaos[company,v]=0;
         veh_pilots[company,v]=0;
-        veh_lid[company,i]=0;
+        veh_lid[company,v]=0;
         veh_wid[company,v]=2;
         veh_uid[company,v]=0;
     }
 }
-
-v=0;company=0;
 
 /*if (obj_creation.fleet_type=3){
     obj_controller.penitent=1;


### PR DESCRIPTION
Fixes an issue in `obj_ini/Create_0.gml` where the incorrect index variable was used during the initialization of vehicle data arrays. 

Removed redundant variable initializations `v=0;` and `company=0;` at the end of the script since they are unnecessary.