### PR TITLE
fix: ensure correct fleet target handling and recursion

### DIFF
--- a/objects/obj_en_fleet/Alarm_4.gml
+++ b/objects/obj_en_fleet/Alarm_4.gml
@@ -39,7 +39,7 @@ if (action==""){
     fleet=id;
     sys=instance_nearest(action_x,action_y,obj_star);
     sys_dist=point_distance(action_x,action_y,sys.x,sys.y);
-    if (scr_valid_fleet_target()){
+    if (scr_valid_fleet_target(target)){
         target_dist=point_distance(x,y,target.action_x,target.action_y);
     }
     
@@ -62,7 +62,7 @@ if (action==""){
         var eta=0;
         
         if (trade_goods!="") and (owner != eFACTION.Tyranids) and (owner != eFACTION.Chaos) and (string_count("Inqis",trade_goods)=0) and (string_count("merge",trade_goods)=0)and (string_count("_her",trade_goods)=0) and (trade_goods!="cancel_inspection") and (trade_goods!="return"){
-            if (scr_valid_fleet_target()){
+            if (scr_valid_fleet_target(target)){
                 if (target.action!=""){
                     if (target_dist>sys_dist){
                         action_x=target.action_x;

--- a/objects/obj_en_fleet/Alarm_4.gml
+++ b/objects/obj_en_fleet/Alarm_4.gml
@@ -41,6 +41,8 @@ if (action==""){
     sys_dist=point_distance(action_x,action_y,sys.x,sys.y);
     if (scr_valid_fleet_target(target)){
         target_dist=point_distance(x,y,target.action_x,target.action_y);
+    } else {
+        target=0;
     }
     
     act_dist=point_distance(x,y,sys.x,sys.y);
@@ -70,8 +72,10 @@ if (action==""){
                         sys=instance_nearest(action_x,action_y,obj_star);
                     }
                 }
+            } else {
+                target = 0;
             }
-        }        
+        }
         
         eta=floor(point_distance(x,y,action_x,action_y)/action_spd)+1;
         if (connected=0) then eta=eta*2;

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -20,9 +20,6 @@ function scr_valid_fleet_target(target) {
     if (valid) {
         valid = (target.object_index == obj_p_fleet || target.object_index == obj_en_fleet);
     }
-    if (!valid) {
-        target = 0;
-    }
     return valid;
 }
 
@@ -40,7 +37,11 @@ function fleets_next_location(fleet = "none", visited = []) {
         // Check if the fleet has a 'target' variable
         if (variable_instance_exists(fleet, "target")) {
             // If the target is valid and not already in the visited list, proceed recursively
-            if (scr_valid_fleet_target(fleet.target) && !array_contains(visited, fleet.target.id)) {
+            var fleet_target_valid = scr_valid_fleet_target(fleet.target);
+            if (!fleet_target_valid) {
+                fleet.target = 0;
+            }
+            if (fleet_target_valid && !array_contains(visited, fleet.target.id)) {
                 // Recursive call with the target and the updated visited list
                 targ_location = fleets_next_location(fleet.target, visited);
             } else if (fleet.action != "") {

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -8,39 +8,59 @@ function set_fleet_target(targ_x, targ_y, final_target){
 	action_eta=floor(point_distance(x,y,targ_x,targ_y)/128)+1;
 }
 
-function scr_valid_fleet_target(){
-	if (target==noone) then return false;
-	if (is_string(target)){
-		target=noone;
-		return false;
-	}
-	var valid = instance_exists(target);
-	if (valid){
-		valid = (target.object_index == obj_p_fleet || target.object_index == obj_en_fleet);
-	}
-	if (!valid) then target=0;
-	return valid;
+function scr_valid_fleet_target(target) {
+    if (target == noone) {
+        return false;
+    }
+    if (is_string(target)) {
+        target = noone;
+        return false;
+    }
+    var valid = instance_exists(target);
+    if (valid) {
+        valid = (target.object_index == obj_p_fleet || target.object_index == obj_en_fleet);
+    }
+    if (!valid) {
+        target = 0;
+    }
+    return valid;
 }
 
-function fleets_next_location(fleet="none"){
-	var targ_location ="none";
-	scr_valid_fleet_target();
-	if (fleet=="none"){
-		if (action!=""){
-	        var goal_x=action_x;
-	        var goal_y=action_y;
-	        targ_location=instance_nearest(goal_x,goal_y,obj_star);
-		} else {
-			targ_location=instance_nearest(x,y,obj_star);
-		}		
-	} else if (instance_exists(fleet)){
-		with (fleet){
-			targ_location = fleets_next_location();
-		}
-	}
-	return targ_location;
+function fleets_next_location(fleet = "none", visited = []) {
+    var targ_location = "none";
+
+    if (fleet == "none") {
+        fleet = self;
+    }
+
+    if (instance_exists(fleet)) {
+        // Add the current fleet's ID to the visited list to avoid rechecking it
+        array_push(visited, fleet.id);
+
+        // Check if the fleet has a 'target' variable
+        if (variable_instance_exists(fleet, "target")) {
+            // If the target is valid and not already in the visited list, proceed recursively
+            if (scr_valid_fleet_target(fleet.target) && !array_contains(visited, fleet.target.id)) {
+                // Recursive call with the target and the updated visited list
+                targ_location = fleets_next_location(fleet.target, visited);
+            } else if (fleet.action != "") {
+                // If no valid target, use the fleet's action coordinates
+                targ_location = instance_nearest(fleet.action_x, fleet.action_y, obj_star);
+            } else {
+                // Default to nearest star to fleet's current position
+                targ_location = instance_nearest(fleet.x, fleet.y, obj_star);
+            }
+        }
+    }
+    // If targ_location was not set to anything else, default to the nearest star
+    if (targ_location == "none") {
+        targ_location = instance_nearest(fleet.x, fleet.y, obj_star);
+    }
+    return targ_location;
 }
-function chase_fleet_target_set(){
+
+
+function chase_fleet_target_set(target){
 	var targ_location = fleets_next_location(target);
 	if (targ_location!="none"){
 		action_x=targ_location.x;


### PR DESCRIPTION
This PR refines fleet target validation and recursive navigation:

1. **Refactored `scr_valid_fleet_target`**: Now takes a `target` parameter for consistent validation.

2. **Improved `fleets_next_location`**:
   - Added recursion with a visited check to prevent infinite loops.
   - Simplified following the logic for recursion.

3. **Standardized calls to `scr_valid_fleet_target`**: Ensured consistency across the codebase.

These changes fix potential issues with fleet chasing loops and enhance code readability.