### PR TITLE
Pr/14 newsmarmour

### DIFF
--- a/objects/obj_mass_equip/Step_0.gml
+++ b/objects/obj_mass_equip/Step_0.gml
@@ -170,6 +170,8 @@ if (refresh=true) and (obj_controller.settings>0){
                     var yes=false;
                     if (req_armour="Power Armour"){
                         if (obj_ini.armour[co][i]="Power Armour") then yes=true;
+                        if (obj_ini.armour[co][i]="MK1 Thunder Armour") then yes=true;
+                        if (obj_ini.armour[co][i]="MK2 Crusade Armour") then yes=true;
                         if (obj_ini.armour[co][i]="MK3 Iron Armour") then yes=true;
                         if (obj_ini.armour[co][i]="MK4 Maximus") then yes=true;
                         if (obj_ini.armour[co][i]="MK6 Corvus") then yes=true;
@@ -178,8 +180,10 @@ if (refresh=true) and (obj_controller.settings>0){
                         if (obj_ini.armour[co][i]="Artificer Armour") then yes=true;
                     }
                     if (req_armour="Terminator Armour"){
+                        if (obj_ini.armour[co][i]="Heavy Power Armour") then yes=true;
                         if (obj_ini.armour[co][i]="Terminator Armour") then yes=true;
                         if (obj_ini.armour[co][i]="Tartaros") then yes=true;
+                        if (obj_ini.armour[co][i]="Cataphractii Pattern Terminator") then yes=true;
                     }
                     if (req_armour="Scout Armour") and (obj_ini.armour[co][i]="Scout Armour") then yes=true;
                     if (string_count("&",obj_ini.armour[co][i])>0) then yes=true;
@@ -332,11 +336,16 @@ if (refresh=true) and (obj_controller.settings>0){
         have_armour_num+=scr_item_count("Power Armour");
         have_armour_num+=scr_item_count("MK4 Maximus");
         have_armour_num+=scr_item_count("MK5 Heresy");
-        have_armour_num+=scr_item_count("MK3 Iron");
+        have_armour_num+=scr_item_count("MK3 Iron Armour");
+        have_armour_num+=scr_item_count("MK2 Crusade Armour");
+        have_armour_num+=scr_item_count("MK1 Thunder Armour");
+        have_armour_num+=scr_item_count("Artificer Armour");
     }
     if (req_armour="Terminator Armour"){
+        have_armour_num+=scr_item_count("Heavy Power Armour");
         have_armour_num+=scr_item_count("Terminator Armour");
         have_armour_num+=scr_item_count("Tartaros");
+        have_armour_num+=scr_item_count("Cataphractii Pattern Terminator");
     }
     if (req_armour="Scout Armour") then have_armour_num+=scr_item_count("Scout Armour");
     have_armour_num+=scr_item_count(req_armour);

--- a/objects/obj_shop/Create_0.gml
+++ b/objects/obj_shop/Create_0.gml
@@ -458,6 +458,22 @@ if (shop = "equipment") {
 }
 if (shop = "equipment2") {
     i = 0;
+	i += 1;
+    item[i] = "MK1 Thunder Armour";
+    item_stocked[i] = scr_item_count("MK1 Thunder Armour");
+    nobuy[i] = 1; // TODO - add images and capability to craft/purchase
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
+	i += 1;
+    item[i] = "MK2 Crusade Armour";
+    item_stocked[i] = scr_item_count("MK2 Crusade Armour");
+    nobuy[i] = 1; // TODO - add images and capability to craft/purchase
+    if (rene = 1) {
+        nobuy[i] = 1;
+        item_cost[i] = 0;
+    }
     i += 1;
     item[i] = "MK3 Iron Armour";
     item_stocked[i] = scr_item_count("MK3 Iron Armour");
@@ -584,10 +600,16 @@ if (shop = "equipment2") {
         item_cost[i] = 0;
     }
     i += 1;
+    item[i] = "Heavy Power Armour";
+    item_stocked[i] = scr_item_count("Heavy Power Armour");
+    // item_cost[i] = 275;
+    // forge_cost[i] = 2750;
+    nobuy[i] = 1;
+    i += 1;
     item[i] = "Terminator Armour";
     item_stocked[i] = scr_item_count("Terminator Armour");
     nobuy[i] = 1;
-    if (obj_controller.stc_wargear >= 6) {
+    if (obj_controller.stc_wargear >= 6) { // TODO - rework trade system
         if (research.armour[1].stealth[0] >0 && research.armour[1].armour[0] >1){
             forge_cost[i] = 4000;
         } else {
@@ -598,6 +620,10 @@ if (shop = "equipment2") {
     i += 1;
     item[i] = "Tartaros";
     item_stocked[i] = scr_item_count("Tartaros");
+    nobuy[i] = 1;
+    i += 1;
+    item[i] = "Cataphractii Pattern Terminator";
+    item_stocked[i] = scr_item_count("Cataphractii Pattern Terminator");
     nobuy[i] = 1;
 
     i += 1;

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -227,18 +227,22 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                 
 					// todo find out what more targ.dudes does, relevant to targ.men?
 	                if (deploying_unit.armour[co][v]="Scout Armour") then targ.dudes_ac[targ.men]=8;
+	                if (deploying_unit.armour[co][v]="MK1 Thunder Armour"){targ.dudes_ac[targ.men]=13;targ.dudes_attack[targ.men]-=0.1;targ.marine_ranged[targ.men]-=0.1;}
+	                if (deploying_unit.armour[co][v]="MK2 Crusade Armour") then targ.dudes_ac[targ.men]=20;
 	                if (deploying_unit.armour[co][v]="MK3 Iron Armour"){targ.dudes_ac[targ.men]=20;targ.dudes_ranged[targ.men]-=0.1;}
 	                if (deploying_unit.armour[co][v]="MK4 Maximus"){targ.dudes_ac[targ.men]=19;targ.dudes_ranged[targ.men]+=0.05;targ.dudes_attack[targ.men]+=0.05;}
-                  if (deploying_unit.armour[co][v]="MK5 Heresy"){targ.dudes_ac[targ.men]=17;targ.dudes_attack[targ.men]+=0.1;targ.marine_ranged[targ.men]-=0.05;}
+                    if (deploying_unit.armour[co][v]="MK5 Heresy"){targ.dudes_ac[targ.men]=17;targ.dudes_attack[targ.men]+=0.1;targ.marine_ranged[targ.men]-=0.05;}
 	                if (deploying_unit.armour[co][v]="MK6 Corvus"){targ.dudes_ac[targ.men]=18;targ.dudes_ranged[targ.men]+=0.1;}
 	                if (deploying_unit.armour[co][v]="MK7 Aquila") then targ.dudes_ac[targ.men]=18;
 	                if (deploying_unit.armour[co][v]="MK8 Errant") then targ.dudes_ac[targ.men]=19;
 	                if (deploying_unit.armour[co][v]="Power Armour") then targ.dudes_ac[targ.men]=19;
 	                if (deploying_unit.armour[co][v]="Artificer Armour"){targ.dudes_ac[targ.men]=35;targ.dudes_attack[targ.men]+=0.1;}
+	                if (deploying_unit.armour[co][v]="Heavy Power Armour"){targ.dudes_ac[targ.men]=35;targ.dudes_ranged[targ.men]-=0.2;targ.dudes_attack[targ.men]-=0.2;}
 	                if (deploying_unit.armour[co][v]="Terminator Armour"){targ.dudes_ac[targ.men]=40;targ.dudes_ranged[targ.men]-=0.1;targ.dudes_attack[targ.men]+=0.2;}
 	                if (deploying_unit.armour[co][v]="Tartaros"){targ.dudes_ac[targ.men]=44;targ.dudes_ranged[targ.men]-=0.05;targ.dudes_attack[targ.men]+=0.2;}
+	                if (deploying_unit.armour[co][v]="Cataphractii Pattern Terminator"){targ.dudes_ac[targ.men]=42;targ.dudes_ranged[targ.men]+=0.0;targ.dudes_attack[targ.men]+=0.2;}
 	                if (deploying_unit.armour[co][v]="Dreadnought") then targ.dudes_ac[targ.men]=40;
-	                if (deploying_unit.armour[co][v]="Ork Armour") then targ.dudes_ac[targ.men]=15;
+	                if (deploying_unit.armour[co][v]="Ork Armour") then targ.dudes_ac[targ.men]=15; // TODO - add skitarii and other hirelings?
                 
 	                if (deploying_unit.wep1[co][v]="Boarding Shield") then targ.dudes_ac[targ.men]+=4;
 	                if (deploying_unit.wep2[co][v]="Boarding Shield") then targ.dudes_ac[targ.men]+=4;

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -511,7 +511,7 @@ function scr_initialize_custom() {
 	}
 
 	if (progenitor = 10) { // Pretty sure that's random?
-		var legions = ["Dark Angels",
+		var legions = ["Dark Angels", // TODO - add more options and make them selectable
 			"Emperor's Children",
 			"Iron Warriors",
 			"White Scars",

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1708,7 +1708,7 @@ global.gear = {
 			"tags": ["dreadnought"],
 		},
 	//	Terminator armours
-		/* a low budget and low-tech variant of terminator armour, TODO - add images, and consider the options for consistent naming
+		// a low budget and low-tech variant of terminator armour, TODO - add images, and consider the options for consistent naming
 		"Heavy Power Armour": {
 			"abbreviation": "HPArm",
 			"armour_value": {
@@ -1731,7 +1731,6 @@ global.gear = {
 			"description": "A simple variant of personal heavy power armour. It generally is a modified heavy-duty industrial armour, hence is typically the weakest.",
 			"tags":["terminator"],
 		},
-		*/
 		"Terminator Armour": {
 			"abbreviation": "Indmts",
 			"armour_value": {

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -1684,6 +1684,144 @@ global.weapons = {
 }
 global.gear = {
 	"armour": {
+	//	Dreadnought types
+		"Dreadnought": {
+			"abbreviation": "Drdnght",
+			"armour_value": {
+				"standard": 50,
+				"master_crafted": 55,
+				"artifact": 60
+			},
+			"ranged_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"melee_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"melee_hands": 8,
+			"ranged_hands": 8,
+			"description": "A massive war-machine that can be piloted by an honored Astarte, who otherwise would have fallen in combat. Some of the Astartes consider this a fate worse than death",
+			"tags": ["dreadnought"],
+		},
+	//	Terminator armours
+		/* a low budget and low-tech variant of terminator armour, TODO - add images, and consider the options for consistent naming
+		"Heavy Power Armour": {
+			"abbreviation": "HPArm",
+			"armour_value": {
+				"standard": 35,
+				"master_crafted": 37,
+				"artifact": 40
+			},
+			"ranged_mod": {
+				"standard": -20,
+				"master_crafted": -5,
+				"artifact": 5
+			},
+			"melee_mod": {
+				"standard": -20,
+				"master_crafted": -5,
+				"artifact": 5
+			},
+			"melee_hands": 1,
+			"ranged_hands":1,
+			"description": "A simple variant of personal heavy power armour. It generally is a modified heavy-duty industrial armour, hence is typically the weakest.",
+			"tags":["terminator"],
+		},
+		*/
+		"Terminator Armour": {
+			"abbreviation": "Indmts",
+			"armour_value": {
+				"standard": 42,
+				"master_crafted": 46,
+				"artifact": 50
+			},
+			"ranged_mod": {
+				"standard": -10,
+				"master_crafted": -5,
+				"artifact": 0
+			},
+			"melee_mod": {
+				"standard": 20,
+				"master_crafted": 25,
+				"artifact": 30
+			},
+			"melee_hands": 2,
+			"ranged_hands": 2,
+			"description": "Terminator Armour is the strongest and most powerful armour designed by humanity, available only to the veterans of the Adeptus Astartes. The Indomitus Pattern is the most widespread and versatile pattern as of M41.",
+			"tags": ["terminator"],
+			"req_exp": 100,
+		},
+		"Tartaros": {
+			"abbreviation": "Tartrs",
+			"armour_value": {
+				"standard": 42,
+				"master_crafted": 46,
+				"artifact": 50
+			},
+			"ranged_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"melee_mod": {
+				"standard": 20,
+				"master_crafted": 25,
+				"artifact": 30
+			},
+			"melee_hands": 2,
+			"ranged_hands": 2,
+			"description": "This pattern is possibly considered the most advanced form of Terminator Armour, providing greater mobility for the wearer compared to the Indomitus with no loss in durability. In the M41 considered to be incredibly rare with wars being fought to secure more suits.",
+			"tags": ["terminator"],
+			"req_exp": 100,
+		},
+		"Cataphractii Pattern Terminator": { // TODO - make naming consistent with other terminator armours
+			"abbreviation": "Catphr",
+			"armour_value": {
+				"standard": 42,
+				"master_crafted": 46,
+				"artifact": 50
+			},
+			"ranged_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"melee_mod": {
+				"standard": 20,
+				"master_crafted": 25,
+				"artifact": 30,
+			},
+			"melee_hands": 2,
+			"ranged_hands": 2,
+			"description": "Among the first issued to the Space Marine Legions. Having additional plating and shield generators installed within the shoulder pads resulted in severe straining of the suit's exoskeleton and reduced the wearer's maneuverability, leading to its decline among some legions.",
+			"tags": ["terminator"],
+			"req_exp": 100,
+		},
+	//	Scout-tier armours
+		"Scout Armour": {
+			"abbreviation": "SctArm",
+			"armour_value": {
+				"standard": 11,
+				"master_crafted": 12,
+				"artifact": 14
+			},
+			"ranged_mod": {
+				"standard": 15,
+				"master_crafted": 20, // Augmented
+				"artifact": 25 // Augmented
+			},
+			"melee_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"description": "A non-powered suit made up of carapace armour and ballistic nylon. Includes biohazard shielding, nutrient feed, and camouflage."
+		},
+	//	Power armours
 		"Power Armour": {
 			"abbreviation": "PwrArm",
 			"armour_value": {
@@ -1724,12 +1862,12 @@ global.gear = {
 			"description": "A custom suit of power armored created by master artificiers and decorated without compare, this ancient Power Armour is beyond priceless. This suit's history is ancient and its users many.",
 			"tags": ["power_armour"],
 		},
-		"Terminator Armour": {
-			"abbreviation": "Indmts",
+		"MK1 Thunder Armour": {
+			"abbreviation": "MK1",
 			"armour_value": {
-				"standard": 42,
-				"master_crafted": 46,
-				"artifact": 50
+				"standard": 13,
+				"master_crafted": 15,
+				"artifact": 17
 			},
 			"ranged_mod": {
 				"standard": -10,
@@ -1737,121 +1875,34 @@ global.gear = {
 				"artifact": 0
 			},
 			"melee_mod": {
+				"standard": -10,
+				"master_crafted": -5, // Augmented
+				"artifact": 0 // Augmented
+			},
+			"description": "The very first variant of power armour. Lacking life support and other later improvements, this armour is mostly suited to ceremonial duty nowadays.",
+			"tags":["power_armour"],
+		},
+		"MK2 Crusade Armour": {
+			"abbreviation": "MK2",
+			"armour_value": {
 				"standard": 20,
-				"master_crafted": 25,
-				"artifact": 30
-			},
-			"melee_hands": 2,
-			"ranged_hands": 2,
-			"description": "Terminator Armour is the strongest and most powerful armour designed by humanity, available only to the veterans of the Adeptus Astartes. The Indomitus Pattern is the most widespread and versatile pattern as of M41.",
-			"tags": ["terminator"],
-			"req_exp": 100,
-		},
-		"Dreadnought": {
-			"abbreviation": "Drdnght",
-			"armour_value": {
-				"standard": 50,
-				"master_crafted": 55,
-				"artifact": 60
+				"master_crafted": 23,
+				"artifact": 25
 			},
 			"ranged_mod": {
 				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
+				"master_crafted": 5,
+				"artifact": 10
 			},
 			"melee_mod": {
 				"standard": 0,
 				"master_crafted": 5, // Augmented
 				"artifact": 10 // Augmented
 			},
-			"melee_hands": 8,
-			"ranged_hands": 8,
-			"description": "A massive war-machine that can be piloted by an honored Astarte, who otherwise would have fallen in combat. Some of the Astartes consider this a fate worse than death",
-			"tags": ["dreadnought"],
-		},
-		"Tartaros": {
-			"abbreviation": "Tartrs",
-			"armour_value": {
-				"standard": 42,
-				"master_crafted": 46,
-				"artifact": 50
-			},
-			"ranged_mod": {
-				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
-			},
-			"melee_mod": {
-				"standard": 20,
-				"master_crafted": 25,
-				"artifact": 30
-			},
-			"melee_hands": 2,
-			"ranged_hands": 2,
-			"description": "This pattern is possibly considered the most advanced form of Terminator Armour, providing greater mobility for the wearer compared to the Indomitus with no loss in durability. In the M41 considered to be incredibly rare with wars being fought to secure more suits.",
-			"tags": ["terminator"],
-			"req_exp": 100,
-		},
-		"Cataphractii Pattern Terminator": {
-			"abbreviation": "Catphr",
-			"armour_value": {
-				"standard": 42,
-				"master_crafted": 46,
-				"artifact": 50
-			},
-			"ranged_mod": {
-				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
-			},
-			"melee_mod": {
-				"standard": 20,
-				"master_crafted": 25,
-				"artifact": 30,
-			},
-			"melee_hands": 2,
-			"ranged_hands": 2,
-			"description": "Among the first issued to the Space Marine Legions. Having additional plating and shield generators installed within the shoulder pads resulted in severe straining of the suit's exoskeleton and reduced the wearer's maneuverability, leading to its decline among some legions.",
-			"tags": ["terminator"],
-			"req_exp": 100,
-		},
-		"Ork Armour": {
-			"abbreviation": "OrkArm",
-			"armour_value": {
-				"standard": 7,
-				"master_crafted": 8,
-				"artifact": 9
-			},
-			"ranged_mod": {
-				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
-			},
-			"melee_mod": {
-				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
-			},
-			"description": "Mismatched basic armour used by ork forces"
-		},
-		"Scout Armour": {
-			"abbreviation": "SctArm",
-			"armour_value": {
-				"standard": 11,
-				"master_crafted": 12,
-				"artifact": 14
-			},
-			"ranged_mod": {
-				"standard": 15,
-				"master_crafted": 20, // Augmented
-				"artifact": 25 // Augmented
-			},
-			"melee_mod": {
-				"standard": 0,
-				"master_crafted": 5, // Augmented
-				"artifact": 10 // Augmented
-			},
-			"description": "A non-powered suit made up of carapace armour and ballistic nylon. Includes biohazard shielding, nutrient feed, and camouflage."
+			// "melee_hands": 0.05,
+			// "ranged_hands": 0.05,
+			"description": "Armour made with Great Crusade in mind. Often believed to be the most efficient power armour design.",
+			"tags":["power_armour"],
 		},
 		"MK3 Iron Armour": {
 			"abbreviation": "MK3",
@@ -1993,6 +2044,7 @@ global.gear = {
 			"description": "The MKX Tacticus is the most advanced pattern of power armour available to the Adeptus Astartes, featuring advanced armor composites and systems. It was developed by Belisarius Cawl during the development of the Primaris Astartes program.",
 			"tags": ["power_armour"],
 		},
+	//	Hireling armours
 		"Skitarii Armour": {
 			"abbreviation": "SkitArm",
 			"description": "Skitarri Armour is something of a misnomer as most Skitarii are in fact bonded more or less permenantly to their advanced mars armour",
@@ -2011,6 +2063,53 @@ global.gear = {
 				"artifact": 16 // Augmented
 			},
 		},
+		"Light Power Armour":{
+			"abbreviation": "LPArm",
+			"description": "A type of power armour that can be used by regular humans.",
+			"armour_value": { // TODO - needs rebalancing, also in scr_weapon_en and other places
+				"standard": 20,
+				"master_crafted": 22,
+				"artifact": 25
+			},
+		},
+		"Ranger Armour":{
+			"abbreviation": "RngrArm",
+			"description": "This armour is used by eldar rangers.",
+			"armour_value": {
+				"standard": 25,
+				"master_crafted": 27,
+				"artifact": 30
+			},
+		},
+		"Ork Armour": {
+			"abbreviation": "OrkArm",
+			"armour_value": {
+				"standard": 7,
+				"master_crafted": 8,
+				"artifact": 9
+			},
+			"ranged_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"melee_mod": {
+				"standard": 0,
+				"master_crafted": 5, // Augmented
+				"artifact": 10 // Augmented
+			},
+			"description": "Mismatched basic armour used by ork forces"
+		},
+		"Fire Warrior Armour": {
+			"abbreviation": "FWarArm",
+			"description": "This armour is used by T'au fire warriors.",
+			"armour_value": { // TODO - needs rebalancing
+				"standard": 20,
+				"master_crafted": 22,
+				"artifact": 25
+			},
+		},
+	//	Vehicle armour
 		"Armoured Ceramite": {
 			"abbreviation": "ArmCrmt",
 			"description": "Supplemental ceramite armour packages provide protection far beyond stock configurations while also adding significant weight to the chassis.",

--- a/scripts/scr_weapons_equip/scr_weapons_equip.gml
+++ b/scripts/scr_weapons_equip/scr_weapons_equip.gml
@@ -344,6 +344,8 @@ function scr_weapons_equip() {
 	        i+=1;item_name[i]="(None)";
 	        i+=1;item_name[i]="Scout Armour";
 	        i+=1;item_name[i]="Power Armour";
+			i+=1;item_name[i]="MK1 Thunder Armour";
+			i+=1;item_name[i]="MK2 Crusade Armour";
 	        i+=1;item_name[i]="MK3 Iron Armour";
 	        i+=1;item_name[i]="MK4 Maximus";
 	        i+=1;item_name[i]="MK5 Heresy";
@@ -352,7 +354,9 @@ function scr_weapons_equip() {
 	        i+=1;item_name[i]="MK8 Errant";
 	        i+=1;item_name[i]="Artificer Armour";
 	        i+=1;item_name[i]="Terminator Armour";
+	        i+=1;item_name[i]="Heavy Power Armour";
 	        i+=1;item_name[i]="Tartaros";
+	        i+=1;item_name[i]="Cataphractii Pattern Terminator";
 	    }
 
 	    else i+=1;

--- a/scripts/scr_wep_abbreviate/scr_wep_abbreviate.gml
+++ b/scripts/scr_wep_abbreviate/scr_wep_abbreviate.gml
@@ -13,16 +13,20 @@ function scr_wep_abbreviate(argument0) {
 	}
 
 	if (we="Scout Armour") then we2="Scout";
+	if (we="MK1 Thunder Armour") then we2="MK1";
+	if (we="MK2 Crusade Armour") then we2="MK2";
 	if (we="MK3 Iron Armour") then we2="MK3";
 	if (we="MK4 Maximus") then we2="MK4";
-        if (we="MK5 Heresy") then we2="MK5";
+	if (we="MK5 Heresy") then we2="MK5";
 	if (we="MK6 Corvus") then we2="MK6";
 	if (we="MK7 Aquila") then we2="MK7";
 	if (we="MK8 Errant") then we2="MK8";
 	if (we="Power Armour") then we2="PA";
 	if (we="Artificer Armour") then we2="Arti";
+	if (we="Heavy Power Armour") then we2="HPArm";
 	if (we="Terminator Armour") then we2="Termi";
 	if (we="Tartaros") then we2="Tarta";
+	if (we="Cataphractii Pattern Terminator") then we2="Catphr";
 	if (we="Dreadnought") then we2="Dread";
 	if (we="Jump Pack") then we2="Jump";
 	if (we="Narthecium") then we2="Narth";


### PR DESCRIPTION
Adds Mark 1, 2 and heavy PA variants. Currently not build-able, more as reference, and need images.
More hireling armors added.
Added more TODO comments.