### PR TITLE
inquisitor inspection target fleet no longer valid bug

### DIFF
--- a/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
+++ b/scripts/scr_inquisition_fleet_functions/scr_inquisition_fleet_functions.gml
@@ -234,7 +234,7 @@ function inquisitor_ship_approaches(){
     var approach_system = instance_nearest(action_x,action_y,obj_star);
     var inquis_string;
     var do_alert = false;
-    if (string_count("fleet",trade_goods)>0){
+    if (string_count("fleet",trade_goods)>0 &&  scr_valid_fleet_target(target)){
         var player_fleet_location = fleets_next_location(target);
         if (player_fleet_location != "none"){
             if (approach_system.name==player_fleet_location.name){


### PR DESCRIPTION
fixes a bug where the target fleet of an inquisitor inspection would no longer be valid