### PR TITLE
Deprecating obj_ini.experience

### DIFF
--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -392,6 +392,9 @@ if (training_psyker>0){
             psyker_aspirant=1;
             
             if (string_count("Abund",obj_ini.strin)>0) then obj_ini.experience[0][g1]+=floor(random(5))+3;
+            if (scr_has_adv("Psyker Abundance")){
+                unit.add_exp(irandom_range(5, 8));
+            }
 
             unit.update_gear("");
             unit.update_mobility_item("");

--- a/objects/obj_controller/Alarm_5.gml
+++ b/objects/obj_controller/Alarm_5.gml
@@ -391,7 +391,6 @@ if (training_psyker>0){
             unit.update_powers();
             psyker_aspirant=1;
             
-            if (string_count("Abund",obj_ini.strin)>0) then obj_ini.experience[0][g1]+=floor(random(5))+3;
             if (scr_has_adv("Psyker Abundance")){
                 unit.add_exp(irandom_range(5, 8));
             }

--- a/objects/obj_controller/KeyPress_73.gml
+++ b/objects/obj_controller/KeyPress_73.gml
@@ -8,10 +8,6 @@ if (audio_is_playing(snd_blood)=true) then scr_music("royal",2000);
 scr_dialogue("lol");
 */
 
-/*var g;g=0;
-repeat(100){g+=1;
-    show_message(string(obj_ini.role[0,g])+": "+string(obj_ini.experience[0,g]));
-}*/
 
 
 // alarm[7]=1;

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -316,7 +316,7 @@ if (menu==1 && (managing>0 || managing<0)){
             }                                      
             //if (string_count("&",temp[106])>0) then temp[106]=clean_tags(temp[106]);
             // Experience
-            temp[113]=string(floor(unit.experience()));
+            temp[113]=string(floor(unit.experience));
             // Bonuses
             temp[119]="";
             if (string_length(unit.specials())>0){

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -670,7 +670,8 @@ ye=99;i=-1;repeat(51){i+=1;
     wep2[ye,i]="";
     armour[ye,i]="";
     gear[ye,i]="";
-    mobi[ye,i]="";experience[ye,i]=0;
+    mobi[ye,i]="";
+    
 }
 ye=100;i=-1;repeat(51){i+=1;
     race[ye,i]=1;loc[ye,i]="";
@@ -679,7 +680,7 @@ ye=100;i=-1;repeat(51){i+=1;
     wep2[ye,i]="";
     armour[ye,i]="";
     gear[ye,i]="";
-    mobi[ye,i]="";experience[ye,i]=0;
+    mobi[ye,i]="";
 }
 ye=101;i=-1;repeat(51){i+=1;
     race[ye,i]=1;loc[ye,i]="";
@@ -688,7 +689,7 @@ ye=101;i=-1;repeat(51){i+=1;
     wep2[ye,i]="";
     armour[ye,i]="";
     gear[ye,i]="";
-    mobi[ye,i]="";experience[ye,i]=0;
+    mobi[ye,i]="";
 }
 ye=102;i=-1;repeat(51){i+=1;
     race[ye,i]=1;loc[ye,i]="";
@@ -697,7 +698,7 @@ ye=102;i=-1;repeat(51){i+=1;
     wep2[ye,i]="";
     armour[ye,i]="";
     gear[ye,i]="";
-    mobi[ye,i]="";experience[ye,i]=0;
+    mobi[ye,i]="";
 }
 ye=103;i=-1;repeat(51){i+=1;
     race[ye,i]=1;loc[ye,i]="";
@@ -706,7 +707,7 @@ ye=103;i=-1;repeat(51){i+=1;
     wep2[ye,i]="";
     armour[ye,i]="";
     gear[ye,i]="";
-    mobi[ye,i]="";experience[ye,i]=0;
+    mobi[ye,i]="";
 }
 
 

--- a/objects/obj_p_assra/Step_0.gml
+++ b/objects/obj_p_assra/Step_0.gml
@@ -87,7 +87,7 @@ if (boarding=true) and (board_cooldown>=0) and (instance_exists(target)) and (in
             if (unit.hp()>0){
                 
                 // Bonuses
-                difficulty+=unit.experience()/20;
+                difficulty+=unit.experience/20;
                 difficulty+=(1-(target.hp/target.maxhp))*33;
                 //TODO define tag for bording weapons
                 if (array_contains(["Chainfist","Meltagun","Lascutter","Boarding Shield"], unit.weapon_one())) then difficulty+=3;
@@ -317,7 +317,7 @@ if (boarding=true) and (board_cooldown>=0) and (instance_exists(target)) and (in
                 co=origin.board_co[o];
                 i=origin.board_id[o];               
                 unit = obj_ini.TTRPG[co][i];
-                unit_exp=unit.experience()                
+                unit_exp=unit.experience                
                 exp_roll=irandom(150+unit_exp)+1;
                 if (exp_roll>=unit_exp){
                     if (unit_exp<50){new_exp=experience

--- a/objects/obj_pnunit/Alarm_5.gml
+++ b/objects/obj_pnunit/Alarm_5.gml
@@ -7,7 +7,7 @@ if (obj_ncombat.defeat=0){
         if (is_struct(unit)){
             if (marine_dead[i]=0) and (obj_ncombat.player_max<obj_ncombat.enemy_max) and (ally[i]==false){
                 new_exp=0;
-                cur_exp=unit.experience();
+                cur_exp=unit.experience;
                 if (cur_exp>=40) then new_exp+=choose(0,0,1);
                 if (cur_exp>=20) and (cur_exp<40) then new_exp+=choose(0,1);
                 if (cur_exp<20) then new_exp+=1;

--- a/objects/obj_popup/Draw_0.gml
+++ b/objects/obj_popup/Draw_0.gml
@@ -909,7 +909,7 @@ if (zoom=0) and (type=6) and (instance_exists(obj_controller)){
                     var g=-1,exp_check=0;
                     for (var g=0;g<array_length(obj_controller.display_unit);g++){
                         if (obj_controller.man_sel[g]=1 && is_struct(obj_controller.display_unit[g])){  
-                            if (obj_controller.display_unit[g].experience()<weapon_one_data.req_exp){
+                            if (obj_controller.display_unit[g].experience<weapon_one_data.req_exp){
                                 exp_check=1;
                                 n_good1=0;
                                 warning=$"A unit must have {weapon_one_data.req_exp}+ EXP to use a {weapon_one_data.name}.";
@@ -948,7 +948,7 @@ if (zoom=0) and (type=6) and (instance_exists(obj_controller)){
                     var g,exp_check;g=-1;exp_check=0;
                     for (var g=0;g<array_length(obj_controller.display_unit);g++){
                         if (obj_controller.man_sel[g]=1 && is_struct(obj_controller.display_unit[g])){  
-                            if (obj_controller.display_unit[g].experience()<weapon_two_data.req_exp){
+                            if (obj_controller.display_unit[g].experience<weapon_two_data.req_exp){
                                 exp_check=1;
                                 n_good1=0;
                                 warning=$"A unit must have {weapon_two_data.req_exp}+ EXP to use a {weapon_two_data.name}.";
@@ -991,7 +991,7 @@ if (zoom=0) and (type=6) and (instance_exists(obj_controller)){
                         var g,exp_check;g=-1;exp_check=0;
                         for (var g=0;g<array_length(obj_controller.display_unit);g++){
                             if (obj_controller.man_sel[g]=1 && is_struct(obj_controller.display_unit[g])){  
-                                if (obj_controller.display_unit[g].experience()<armour_data.req_exp){
+                                if (obj_controller.display_unit[g].experience<armour_data.req_exp){
                                     exp_check=1;
                                     n_good1=0;
                                     warning=$"A unit must have {armour_data.req_exp}+ EXP to use a {armour_data.name}.";

--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -1379,7 +1379,7 @@ if (image=="new_forge_master"){
             if (techs[charisma_pick].charisma < techs[i].charisma){
                 charisma_pick=i;
             }
-            if (techs[experience_pick].experience() < techs[i].experience()){
+            if (techs[experience_pick].experience < techs[i].experience){
                 experience_pick=i;
             }
             if (techs[talent_pick].technology < techs[i].technology){
@@ -1416,9 +1416,9 @@ if (image=="new_forge_master"){
                             skill_lack++;
                             cur_tech.loyalty-=cur_tech.technology-pick.technology;
                         }
-                         if (pick.experience()<cur_tech.experience()){
+                         if (pick.experience<cur_tech.experience){
                             exp_lack++;
-                            cur_tech.loyalty-=floor((cur_tech.experience()-pick.experience())/200);
+                            cur_tech.loyalty-=floor((cur_tech.experience-pick.experience)/200);
                         }
                         if (charisma_test[0]==2){
                             dislike++;

--- a/scripts/scr_add_man/scr_add_man.gml
+++ b/scripts/scr_add_man/scr_add_man.gml
@@ -28,7 +28,6 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 		obj_ini.wep1[target_company][good] = "";
 		obj_ini.wep2[target_company][good] = "";
 		obj_ini.armour[target_company][good] = "";
-		obj_ini.experience[target_company][good] = spawn_exp;
 		obj_ini.spe[target_company][good] = "";
 		obj_ini.god[target_company][good] = 0;
 
@@ -42,7 +41,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Hellgun";
 				obj_ini.wep2[target_company][good] = ""; // Consider giving the poor fellow a "Combat Knife" or other melee weapon
 				obj_ini.armour[target_company][good] = "Skitarii Armour";
-				obj_ini.experience[target_company][good] = 10;
+				spawn_exp = 10;
 				obj_ini.race[target_company][good] = 3;
 				unit = new TTRPG_stats("mechanicus", target_company, good, "skitarii");
 				break;
@@ -52,7 +51,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.armour[target_company][good] = "Dragon Scales";
 				obj_ini.gear[target_company][good] = "";
 				obj_ini.mobi[target_company][good] = "Servo-arm";
-				obj_ini.experience[target_company][good] = 100;
+				spawn_exp = 100;
 				obj_ini.race[target_company][good] = 3;
 				unit = new TTRPG_stats("mechanicus", target_company, good, "tech_priest");
 				break
@@ -61,7 +60,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Power Sword";
 				obj_ini.armuor[target_company][good] = "Power Armour"; // Might want to create "Light Power Armour" that is suited for squishy humans
 				obj_ini.gear[target_company][good] = "Storm Shield";
-				obj_ini.experience[target_company][good] = 10;
+				spawn_exp = 10;
 				obj_ini.race[target_company][good] = 4;
 				unit = new TTRPG_stats("inquisition", target_company, good, "inquisition_crusader");
 				break;
@@ -70,7 +69,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Bolter"; // Might want to create a "Light Bolter" variant for this one
 				obj_ini.wep2[target_company][good] = "Sarissa";
 				obj_ini.armour[target_company][good] = "Power Armour"; // Same here, Sororitas are glorified guard
-				obj_ini.experience[target_company][good] = 60;
+				spawn_exp = 60;
 				obj_ini.race[target_company][good] = 5;
 				unit = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_of_battle");
 				break;
@@ -78,7 +77,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Bolter"; // Same here
 				obj_ini.wep2[target_company][good] = "Sarissa";
 				obj_ini.armour[target_company][good] = "Power Armour"; // Same here
-				obj_ini.experience[target_company][good] = 100;
+				spawn_exp = 100;
 				obj_ini.gear[target_company][good] = "Sororitas Medkit";
 				obj_ini.race[target_company][good] = 5;
 				unit = new TTRPG_stats("adeptus_sororitas", target_company, good, "sister_hospitaler");
@@ -89,7 +88,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Ranger Long Rifle";
 				obj_ini.wep2[target_company][good] = "Shuriken Pistol";
 				obj_ini.armour[target_company][good] = ""; // I should add "Eldar Armour" to the fellow too
-				obj_ini.experience[target_company][good] = 80;
+				spawn_exp = 80;
 				obj_ini.race[target_company][good] = 6
 				unit = new TTRPG_stats("mechanicus", target_company, good, "skitarii_ranger");
 				break;
@@ -98,7 +97,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Sniper Rifle";
 				obj_ini.wep2[target_company][good] = "Choppa";
 				obj_ini.armour[target_company][good] = ""; // Consider giving "Ork Armour" to the fellow
-				obj_ini.experience[target_company][good] = 20;
+				spawn_exp = 20;
 				obj_ini.race[target_company][good] = 7;
 				unit = new TTRPG_stats("ork", target_company, good, "ork_Sniper");
 				break;
@@ -106,7 +105,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 				obj_ini.wep1[target_company][good] = "Snazzgun";
 				obj_ini.wep2[target_company][good] = "Choppa";
 				obj_ini.armour[target_company][good] = "Ork Armour";
-				obj_ini.experience[target_company][good] = 40;
+				spawn_exp = 40;
 				obj_ini.race[target_company][good] = 7;
 				unit = new TTRPG_stats("ork", target_company, good, "flash_git");
 				break;
@@ -249,7 +248,7 @@ function scr_add_man(man_role, target_company, spawn_exp, spawn_name, corruption
 			marines += 1;
 		}
 		obj_ini.TTRPG[target_company][good] = unit;
-
+		unit.add_exp(spawn_exp);
 		unit.allocate_unit_to_fresh_spawn(home_spot);
 		with(obj_ini) {
 			scr_company_order(target_company);

--- a/scripts/scr_civil_roster/scr_civil_roster.gml
+++ b/scripts/scr_civil_roster/scr_civil_roster.gml
@@ -200,7 +200,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
 	                targ.dudes[targ.men]=unit.role();
 	                targ.dudes_num[targ.men]=1;
 	                targ.dudes_hp[targ.men]=unit.hp();
-	                targ.dudes_exp[targ.men]=deploying_unit.experience[cooh,va];
+	                targ.dudes_exp[targ.men]=unit.experience;
 	                targ.dudes_powers[targ.men]=deploying_unit.spe[cooh,va];
 	                targ.dudes_wep1[targ.men]=deploying_unit.wep1[cooh,va];
 	                targ.dudes_wep2[targ.men]=deploying_unit.wep2[cooh,va];
@@ -359,7 +359,7 @@ function scr_civil_roster(_unit_location, _target_location, _is_planet) {
                     targ.marine_gear[targ.men] = deploying_unit.gear[cooh][va];
                     targ.marine_mobi[targ.men] = unit.mobility_item();
                     targ.marine_hp[targ.men] = unit.hp();
-                    targ.marine_exp[targ.men] = deploying_unit.experience[cooh][va];
+                    targ.marine_exp[targ.men] = unit.experience;
                     targ.marine_powers[targ.men] = deploying_unit.spe[cooh][va];
                     targ.marine_ranged[targ.men] = unit.ranged_attack();
                     targ.marine_ac[targ.men]=unit.armour_calc();

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -27,7 +27,6 @@ function temp_marine_variables(co, unit_num){
 		array_push(temp_wep2,wep2[co][unit_num]);
 		array_push(temp_armour,armour[co][unit_num]);
 		array_push(temp_gear,gear[co][unit_num]);
-		array_push(temp_experience,experience[co][unit_num]);
 		array_push(temp_age,age[co][unit_num]);
 		array_push(temp_mobi,mobi[co][unit_num]);
 		array_push(temp_spe,spe[co][unit_num]);
@@ -289,7 +288,6 @@ function scr_company_order(company) {
 	        armour[co][i]=temp_armour[i];
 	        gear[co][i]=temp_gear[i];
 	        mobi[co][i]=temp_mobi[i];
-	        experience[co][i]=temp_experience[i];
 	        age[co][i]=temp_age[i];
 	        spe[co][i]=temp_spe[i];
 	        god[co][i]=temp_god[i];

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -68,7 +68,7 @@ function add_man_to_manage_arrays(unit){
         array_push(ma_health,unit.hp());
         array_push(ma_mobi,unit.mobility_item());
         array_push(ma_chaos,unit.corruption);
-        array_push(ma_exp,unit.experience());
+        array_push(ma_exp,unit.experience);
         array_push(ma_promote,0);
         array_push(display_unit,unit);
         array_push(ma_god,0);
@@ -325,13 +325,13 @@ function other_manage_data(){
 			else if (unit.company >= 6) then target_company = 5;
 			else if (unit.company >= 2) then target_company = 1;
 	    	var promotion_limit = company_promotion_limits[target_company]
-			if (unit.experience()>=promotion_limit && promotion_limit>0){
+			if (unit.experience>=promotion_limit && promotion_limit>0){
 	    		ma_promote[v]=1;
 	    	}
 	    	if (ma_health[v]<=10) then ma_promote[v]=10;	                	
 	    } else if  (ma_role[v]=obj_ini.role[100][5]){
 	    	var promotion_limit = company_promotion_limits[unit.company - 1]
-	    	if (unit.experience()>=promotion_limit+25 && promotion_limit>0){
+	    	if (unit.experience>=promotion_limit+25 && promotion_limit>0){
 
 	    	}
 	    }

--- a/scripts/scr_crusade/scr_crusade.gml
+++ b/scripts/scr_crusade/scr_crusade.gml
@@ -47,7 +47,7 @@ function scr_crusade() {
                 //TODO figure out how to quantify and present these risks so the player knows to protect dudes with trait
                 if (unit.has_trait("very_hard_to_kill")) then death_determination-=20;
                 death_determination_2=death_determination;
-                death_determination-=(unit.experience()/2);
+                death_determination-=(unit.experience/2);
 
                 //more generalised trait bonus mainly linked to chapter advantage of same name
                 if (unit.has_trait("slow_and_purposeful")) then death_determination-=10;

--- a/scripts/scr_draw_armentarium/scr_draw_armentarium.gml
+++ b/scripts/scr_draw_armentarium/scr_draw_armentarium.gml
@@ -134,7 +134,7 @@ function calculate_research_points(turn_end=false){
                 if (struct_exists(gen_data,"crafter")) then crafters++;
                 if (struct_exists(gen_data,"at_forge")){
                     at_forge++;
-                    master_craft_chance += (techs[i].experience()/50)
+                    master_craft_chance += (techs[i].experience/50)
                 }
                 forge_points += forge_point_gen[0];
                 if (techs[i].has_trait("tech_heretic")){

--- a/scripts/scr_garrison/scr_garrison.gml
+++ b/scripts/scr_garrison/scr_garrison.gml
@@ -111,7 +111,7 @@ function GarrisonForce(planet_operatives, turn_end=false, type="garrison") const
 					}
 				}				
 			}else if (hierarchy[leader_hier_pos]==unit.role()){
-				if (garrison_leader.experience()<unit.experience()){
+				if (garrison_leader.experience<unit.experience){
 					garrison_leader=unit;
 				}
 			}else{

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -1167,7 +1167,6 @@ function scr_initialize_custom() {
 		armour[100, i] = "";
 		gear[100, i] = "";
 		mobi[100, i] = "";
-		experience[100, i] = 0;
 		age[100, i] = ((millenium * 1000) + year) - 10;
 		god[100, i] = 0;
 	}
@@ -1185,7 +1184,6 @@ function scr_initialize_custom() {
 		armour[0, i] = "";
 		gear[0, i] = "";
 		mobi[0, i] = "";
-		experience[0, i] = 0;
 		age[0, i] = ((millenium * 1000) + year) - 10;
 		god[0, i] = 0;
 		TTRPG[0, i] = new TTRPG_stats("chapter", 0, i, "blank");
@@ -2475,17 +2473,17 @@ function scr_initialize_custom() {
 	// all of this can now be handled in teh struct and no longer neades complex methods
 	switch (obj_creation.chapter_master_specialty) {
 		case 1:
-			experience[company, 1] = 550;
+			chapter_master.add_exp(550);
 			spe[company, 1] += "$";
 			break;
 		case 2:
-			experience[company, 1] = 650;
+			chapter_master.add_exp(650);
 			spe[company, 1] += "@";
 			chapter_master.add_trait("champion");
 			break;
 		case 3:
 			//TODO phychic powers need a redo but after weapon refactor
-			experience[company, 1] = 550;
+			chapter_master.add_exp(550);
 			gear[company, 1] = "Psychic Hood";
 			var
 			let = "";
@@ -2638,7 +2636,6 @@ function scr_initialize_custom() {
 		wep2[company, 5] = "";
 		armour[company, 5] = "";
 		gear[company, 5] = "";
-		experience[company, 5] = 0;
 		man_size -= 1;
 		commands -= 1;
 		TTRPG[company, 5] = new TTRPG_stats("chapter", company, 1, "blank");
@@ -2676,7 +2673,9 @@ function scr_initialize_custom() {
 		wep1[company][k] = wep1[101, 17];
 		wep2[company][k] = choose_weighted(weapon_weighted_lists.pistols);
 		gear[company][k] = gear[101, 17];
-		if (psyky = 1) then experience[company][k] += 10;
+		if (psyky = 1){
+			spawn_unit.add_exp(10);
+		}
 		var
 		let = "", letmax = 0;
 		if (obj_creation.discipline = "default") {
@@ -2711,6 +2710,7 @@ function scr_initialize_custom() {
 		commands += 1;
 		man_size += 1;
 		TTRPG[company][k] = new TTRPG_stats("chapter", company, k);
+		spawn_unit = TTRPG[company][k];
 		race[company][k] = 1;
 		loc[company][k] = home_name;
 		role[company][k] = "Codiciery";
@@ -2718,7 +2718,9 @@ function scr_initialize_custom() {
 		wep1[company][k] = wep1[101, 17];
 		wep2[company][k] = choose_weighted(weapon_weighted_lists.pistols);
 		gear[company][k] = gear[101, 17];
-		if (psyky = 1) then experience[company][k] += 10;
+		if (psyky = 1){
+			spawn_unit.add_exp(10);
+		}
 		var
 		let, letmax;
 		let = "";
@@ -2757,6 +2759,7 @@ function scr_initialize_custom() {
 		commands += 1;
 		man_size += 1;
 		TTRPG[company][k] = new TTRPG_stats("chapter", company, k);
+		var spawn_unit = TTRPG[company][k];
 		race[company][k] = 1;
 		loc[company][k] = home_name;
 		role[company][k] = "Lexicanum";
@@ -2764,7 +2767,9 @@ function scr_initialize_custom() {
 		wep1[company][k] = wep1[101, 17];
 		wep2[company][k] = choose_weighted(weapon_weighted_lists.pistols);
 		gear[company][k] = gear[101, 17];
-		if (psyky = 1) then experience[company][k] += 10;
+		if (psyky = 1){
+			spawn_unit.add_exp(10);
+		}
 		var
 		let = "", letmax = 0;
 		if (obj_creation.discipline = "default") {
@@ -2881,7 +2886,6 @@ function scr_initialize_custom() {
 		wep2[company, i] = "";
 		armour[company, i] = "";
 		chaos[company, i] = 0;
-		experience[company, i] = 0;
 		gear[company, i] = "";
 		mobi[company, i] = "";
 		age[company, i] = ((millenium * 1000) + year) - 10;
@@ -2990,7 +2994,9 @@ function scr_initialize_custom() {
 			if (terminator <= 0) then armour[company][k] = "MK6 Corvus";
 			if (mobi[101, 15] != "") then mobi[company][k] = mobi[101, 15];
 			if (armour[company][k] = "Terminator") or(armour[company][k] = "Tartaros") then man_size += 1;
-			if (psyky = 1) then experience[company][k] += 10;
+			if (psyky){
+				spawn_unit.add_exp(10);
+			}
 			var let = "";
 			var letmax = 0;
 			if (obj_creation.discipline = "default") {
@@ -3244,7 +3250,6 @@ function scr_initialize_custom() {
 			gear[company, i] = "";
 			mobi[company, i] = "";
 			chaos[company, i] = 0;
-			experience[company, i] = 0;
 			age[company, i] = ((millenium * 1000) + year) - 21 - irandom(6);
 			god[company, i] = 0;
 			TTRPG[company, i] = new TTRPG_stats("chapter", company, i, "blank");
@@ -3578,7 +3583,9 @@ function scr_initialize_custom() {
 				gear[company][k] = gear[101, 17];
 				wep1[company][k] = wep1[101, 17];
 				wep2[company][k] = choose_weighted(weapon_weighted_lists.pistols);
-				if (psyky = 1) then experience[company][k] += 10;
+				if (psyky = 1){
+					spawn_unit.add_exp(10);
+				}
 				var let = "";
 				var letmax = 0;
 				if (obj_creation.discipline = "default") {

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3126,7 +3126,7 @@ function scr_initialize_custom() {
 		name[company][k] = global.name_generator.generate_space_marine_name();
 		spawn_unit = TTRPG[company][k]
 		spawn_unit.roll_age();
-		spawn_unit.roll_experience();
+		spawn_unit.roll_experience;
 	}
 
 	for (i = 0; i < 4; i++) {
@@ -3812,7 +3812,7 @@ function scr_initialize_custom() {
 					armour[company][k] = "Dreadnought";
 					spawn_unit = TTRPG[company][k];
 					spawn_unit.roll_age();
-					spawn_unit.roll_experience();
+					spawn_unit.roll_experience;
 					if (company = 9) then wep1[company][k] = "Missile Launcher";
 				}
 			}

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3132,7 +3132,7 @@ function scr_initialize_custom() {
 		name[company][k] = global.name_generator.generate_space_marine_name();
 		spawn_unit = TTRPG[company][k]
 		spawn_unit.roll_age();
-		spawn_unit.roll_experience;
+		spawn_unit.roll_experience();
 	}
 
 	for (i = 0; i < 4; i++) {
@@ -3819,7 +3819,7 @@ function scr_initialize_custom() {
 					armour[company][k] = "Dreadnought";
 					spawn_unit = TTRPG[company][k];
 					spawn_unit.roll_age();
-					spawn_unit.roll_experience;
+					spawn_unit.roll_experience();
 					if (company = 9) then wep1[company][k] = "Missile Launcher";
 				}
 			}

--- a/scripts/scr_kill_unit/scr_kill_unit.gml
+++ b/scripts/scr_kill_unit/scr_kill_unit.gml
@@ -24,7 +24,6 @@ function scr_wipe_unit(company, unit_slot){
 	obj_ini.armour[company][unit_slot]="";
 	obj_ini.gear[company][unit_slot]="";
 	obj_ini.god[company][unit_slot]=0;
-	obj_ini.experience[company][unit_slot]=0;
 	obj_ini.age[company][unit_slot]=0;
 	obj_ini.mobi[company][unit_slot]="";
 	obj_ini.bio[company][unit_slot]="";

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -370,7 +370,6 @@ function scr_load(save_part, save_id) {
                     obj_ini.gear[coh,mah]=ini_read_string("Mar","ge"+string(coh)+"."+string(mah),"");
                     obj_ini.mobi[coh,mah]=ini_read_string("Mar","mb"+string(coh)+"."+string(mah),"");
 
-                    obj_ini.experience[coh,mah]=ini_read_real("Mar","exp"+string(coh)+"."+string(mah),0);
                     obj_ini.age[coh,mah]=ini_read_real("Mar","ag"+string(coh)+"."+string(mah),0);
                     obj_ini.spe[coh,mah]=ini_read_string("Mar","spe"+string(coh)+"."+string(mah),"");
                     obj_ini.god[coh,mah]=ini_read_real("Mar","god"+string(coh)+"."+string(mah),0);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -701,13 +701,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 	turn_stat_gains = {};
 
 	static update_exp = function(new_val){
-		obj_ini.experience[company][marine_number] = new_val
+		experience = new_val
 	}//change exp
 
 	static add_exp = function(add_val){
 		var instace_stat_point_gains = {};
 		stat_point_exp_marker += add_val;
-		obj_ini.experience[company][marine_number] += add_val;
+		experience += add_val;
 		if (base_group == "astartes"){
 			while (stat_point_exp_marker>=15){
 				var stat_gains = choose("weapon_skill", "ballistic_skill", "wisdom");

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -697,9 +697,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			aspirant_trial : obj_ini.recruit_trial			
 		};
 	}
-	static experience =  function(){
-		return obj_ini.experience[company][marine_number];
-	}//get exp
+	experience = 0;
 	turn_stat_gains = {};
 
 	static update_exp = function(new_val){
@@ -1606,7 +1604,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 		qual_string = quality;
 		if (scr_item_count(new_weapon, quality)>0){
 			var exp_require = gear_weapon_data("weapon", new_weapon, "req_exp", false, quality);
-				if (exp_require>experience()){
+				if (exp_require>experience){
 					viable = false;
 					qual_string = "exp_low";
 				}  			
@@ -1665,7 +1663,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			damage_res+=get_mobility_data("damage_resistance_mod");
 			damage_res+=get_weapon_one_data("damage_resistance_mod");
 			damage_res+=get_weapon_two_data("damage_resistance_mod");			
-			damage_res = min(75, damage_res+floor(((constitution*0.005) + (experience()/1000))*100));
+			damage_res = min(75, damage_res+floor(((constitution*0.005) + (experience/1000))*100));
 			return damage_res;
 		};
 
@@ -1726,9 +1724,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 		static ranged_attack = function(weapon_slot=0){
 			encumbered_ranged=false;			
 			//base modifyer based on unit skill set
-			ranged_att = 100*(((ballistic_skill/50) + (dexterity/400)+ (experience()/500)));
+			ranged_att = 100*(((ballistic_skill/50) + (dexterity/400)+ (experience/500)));
 			var final_range_attack=0;
-			var explanation_string = $"Stat Mod: x{ranged_att/100}#  BS: x{ballistic_skill/50}#  DEX: x{dexterity/400}#  EXP: x{experience()/500}#";
+			var explanation_string = $"Stat Mod: x{ranged_att/100}#  BS: x{ballistic_skill/50}#  DEX: x{dexterity/400}#  EXP: x{experience/500}#";
 			//determine capavbility to weild bulky weapons
 			var carry_data =ranged_hands_limit();
 
@@ -1895,11 +1893,11 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 		}		
 		static melee_attack = function(weapon_slot=0){
 			encumbered_melee=false;
-			melee_att = 100*(((weapon_skill/100) * (strength/20)) + (experience()/1000)+0.1);
+			melee_att = 100*(((weapon_skill/100) * (strength/20)) + (experience/1000)+0.1);
 			var explanation_string = string_concat("#Stats: ", format_number_with_sign(round(((melee_att/100)-1)*100)), "%#");
 			explanation_string += "  Base: +10%#";
 			explanation_string += string_concat("  WSxSTR: ", format_number_with_sign(round((((weapon_skill/100)*(strength/20))-1)*100)), "%#");
-			explanation_string += string_concat("  EXP: ", format_number_with_sign(round((experience()/1000)*100)), "%#");
+			explanation_string += string_concat("  EXP: ", format_number_with_sign(round((experience/1000)*100)), "%#");
 
 			melee_carrying = melee_hands_limit();
 			var _wep1 = get_weapon_one_data();
@@ -1958,9 +1956,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			var basic_wep_string = $"{primary_weapon.name}: {primary_weapon.attack}#";
 			if IsSpecialist("libs") or has_trait("warp_touched"){
 				if (primary_weapon.has_tag("force") ||_wep2.has_tag("force")){
-					var force_modifier = (((weapon_skill/100) * (psionic/10) * (intelligence/10)) + (experience()/1000)+0.1);
+					var force_modifier = (((weapon_skill/100) * (psionic/10) * (intelligence/10)) + (experience/1000)+0.1);
 					primary_weapon.attack *= force_modifier;
-					basic_wep_string += $"Active Force Weapon: x{force_modifier}#  Base: 0.10#  WSxPSIxINT: x{(weapon_skill/100)*(psionic/10)*(intelligence/10)}#  EXP: x{experience()/1000}#";
+					basic_wep_string += $"Active Force Weapon: x{force_modifier}#  Base: 0.10#  WSxPSIxINT: x{(weapon_skill/100)*(psionic/10)*(intelligence/10)}#  EXP: x{experience/1000}#";
 				}		
 			};
 			explanation_string = basic_wep_string + explanation_string
@@ -2348,7 +2346,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 
 	static assign_reactionary_traits = function() {
 		var _age = age();
-		var _exp = experience();
+		var _exp = experience;
 		var _total_score = _age + _exp;
 	
 		if (_total_score > 280){

--- a/scripts/scr_max_marine/scr_max_marine.gml
+++ b/scripts/scr_max_marine/scr_max_marine.gml
@@ -27,8 +27,9 @@ function scr_max_marine(max_type) {
 	            		man_i=i;
 	            	}
 	            }else if (max_type="exp"){
-	            	if (obj_ini.experience[c,i]>value){
-	            		value=obj_ini.experience[c,i];man_c=c;man_i=i;
+	            	if (unit.experience>value){
+	            		value=unit.experience;
+	            		man_c=c;man_i=i;
 	            	}
 	            }
 	        }

--- a/scripts/scr_mission_reward/scr_mission_reward.gml
+++ b/scripts/scr_mission_reward/scr_mission_reward.gml
@@ -31,11 +31,12 @@ function scr_mission_reward(argument0, argument1, argument2) {
 	                    cleanup[com]=1;
 	                }
 	                if (roll2>50){
-	                    argument1.p_player[argument2]+=scr_unit_size(obj_ini.armour[com][i],obj_ini.role[com][i],true);
+	                	var unit = obj_ini.TTRPG[com][i];
+	                    argument1.p_player[argument2]+=unit.get_unit_size();
 	                    obj_ini.loc[com][i]=argument1.name;
-	                    obj_ini.TTRPG[com][i].planet_location=argument2;
+	                    unit.planet_location=argument2;
 	                    techs_alive+=1;
-	                    repeat(3){obj_ini.experience[com][i]+=choose(1,2,3,4,5,6);}
+	                    unit.add_experience(irandom_range(3,18));
 	                    if (roll2<80) then found_requisition+=floor(random_range(5,40))+1;
 	                }
 	                if (roll2>=80) and (roll2<88) then found_requisition+=100;

--- a/scripts/scr_move_unit_info/scr_move_unit_info.gml
+++ b/scripts/scr_move_unit_info/scr_move_unit_info.gml
@@ -18,7 +18,6 @@ function scr_move_unit_info(start_company,end_company, start_slot, end_slot, eva
 		obj_ini.gear[end_company][end_slot]=obj_ini.gear[start_company][start_slot];
 		obj_ini.armour[end_company][end_slot]=obj_ini.armour[start_company][start_slot];
 		obj_ini.god[end_company][end_slot]=obj_ini.god[start_company][start_slot];
-		obj_ini.experience[end_company][end_slot]=obj_ini.experience[start_company][start_slot];
 		obj_ini.age[end_company][end_slot]=obj_ini.age[start_company][start_slot];
 		obj_ini.mobi[end_company][end_slot]=obj_ini.mobi[start_company][start_slot];
 		var temp_struct = jsonify_marine_struct(start_company,start_slot);			//jsonified for stransfer of struct (makes a deep copy)

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -172,7 +172,7 @@ function scr_player_combat_weapon_stacks() {
                     var cast_dice=irandom(99)+1;
                     if (array_contains(obj_ini.dis,"Warp Touched")) then cast_dice-=5;
 
-                    cast_dice-=(unit.psionic+(unit.experience()/60))
+                    cast_dice-=(unit.psionic+(unit.experience/60))
 
                     if (cast_dice<=50) then marine_casting[g]=1;
 
@@ -313,7 +313,7 @@ function scr_add_unit_to_roster(unit, is_ally=false){
     array_push(marine_mobi, unit.mobility_item());
     array_push(marine_hp, unit.hp());
     array_push(marine_mobi, unit.mobility_item());
-    array_push(marine_exp, unit.experience());
+    array_push(marine_exp, unit.experience);
     array_push(marine_powers, unit.specials());
     array_push(marine_ranged, unit.ranged_attack());
     array_push(marine_powers, unit.specials());

--- a/scripts/scr_powers_new/scr_powers_new.gml
+++ b/scripts/scr_powers_new/scr_powers_new.gml
@@ -19,7 +19,7 @@ function scr_powers_new(){
 
 
 	// higer psionice means more powers learnt
-	powers_should_have=floor((experience()-30)/(45-psionic))+1;// +1 for the primary
+	powers_should_have=floor((experience-30)/(45-psionic))+1;// +1 for the primary
 	powers_have=string_count(string(power_code),specials());
 
 

--- a/scripts/scr_random_event/scr_random_event.gml
+++ b/scripts/scr_random_event/scr_random_event.gml
@@ -325,7 +325,7 @@ function scr_random_event(execute_now) {
 			unit.add_exp(10);
 		}
 		else {
-			unit.add_exp(max(20, unit.experience()));
+			unit.add_exp(max(20, unit.experience));
 		}
 		
 		scr_popup("Promotions!",text,"distinguished","");

--- a/scripts/scr_random_marine/scr_random_marine.gml
+++ b/scripts/scr_random_marine/scr_random_marine.gml
@@ -75,7 +75,7 @@ function scr_random_marine(role, exp_req, search_params="none"){
             	}
 
             	//check corect experience
-            	if (unit.experience()<exp_req){
+            	if (unit.experience<exp_req){
 	        		array_delete(marine_list, list_place ,1);
 					comp_size--;
 					continue;	        		

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -541,8 +541,6 @@ function scr_save(save_part,save_id) {
 	                ini_write_string("Mar",$"ar{coh}.{mah}",obj_ini.armour[coh,mah]);
 	                ini_write_string("Mar",$"ge{coh}.{mah}",obj_ini.gear[coh,mah]);
 	                ini_write_string("Mar",$"mb{coh}.{mah}",obj_ini.mobi[coh,mah]);
-
-	                ini_write_real("Mar",$"exp{coh}.{mah}",obj_ini.experience[coh,mah]);
 	                ini_write_real("Mar",$"ag{coh}.{mah}",obj_ini.age[coh,mah]);
 	                ini_write_string("Mar",$"spe{coh}.{mah}",obj_ini.spe[coh,mah]);
 	                ini_write_real("Mar",$"god{coh}.{mah}",obj_ini.god[coh,mah]);

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -72,12 +72,12 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 			for (i = 0; i < array_length(squad.members);i++){
 				if (i==0){
 					exp_unit = fetch_unit(squad.members[0]);
-					highest_exp = exp_unit.experience();
+					highest_exp = exp_unit.experience;
 					continue;
 				}
 				unit = fetch_unit(squad.members[i]);
-				if (unit.experience() > highest_exp){
-					highest_exp = unit.experience();
+				if (unit.experience > highest_exp){
+					highest_exp = unit.experience;
 					exp_unit = unit;
 				};
 			}
@@ -330,8 +330,8 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 				i--;
 				continue;
 			}			
-			if (unit.experience() > highest_exp){
-				highest_exp = unit.experience();
+			if (unit.experience > highest_exp){
+				highest_exp = unit.experience;
 				exp_unit = unit;
 			};
 		}
@@ -538,7 +538,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 						}
 					}
 				}else if (hierarchy[leader_hier_pos]==unit.role()){
-					if (obj_ini.TTRPG[leader[0]][leader[1]].experience()<unit.experience()){
+					if (obj_ini.TTRPG[leader[0]][leader[1]].experience<unit.experience){
 						leader=[unit.company, unit.marine_number];
 					}
 				}else{

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -503,7 +503,7 @@ function scr_ui_manage() {
 							}
 						}
         		var_text = string_hash_to_newline(string("Damage Resistance: {0}",cn.temp[118]))
-	        	tooltip_text += string_hash_to_newline(string("CON: {0}%#XP: {1}%", round(selected_unit.constitution/2), round(selected_unit.experience()/10)));
+	        	tooltip_text += string_hash_to_newline(string("CON: {0}%#XP: {1}%", round(selected_unit.constitution/2), round(selected_unit.experience/10)));
 	        	x1 = x_left;
 	        	y1 = yy+378;
 	        	x2 = x1+string_width(var_text);

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -56,7 +56,7 @@ function scr_update_unit_armour(new_armour, from_armoury=true, to_armoury=true, 
 	  	if (from_armoury && new_armour!="" && !arti && is_struct(_new_armour_data)){
 	  		if (scr_item_count(new_armour,quality)>0){
 				var exp_require = _new_armour_data.req_exp;
-	  			if (exp_require>experience()){
+	  			if (exp_require>experience){
 	  				return "exp_low";
 	  			} 	  			
 		   		quality=scr_add_item(new_armour,-1,quality);
@@ -209,7 +209,7 @@ function scr_update_unit_gear(new_gear,from_armoury=true, to_armoury=true, quali
   	if (from_armoury) and (new_gear!="") and (!arti){
   		if (scr_item_count(new_gear,quality)>0){
 			var exp_require = gear_weapon_data("gear", new_gear, "req_exp", false, quality);
-  			if (exp_require>experience()){
+  			if (exp_require>experience){
   				return "exp_low";
   			}
 	   		quality=scr_add_item(new_gear,-1, quality);
@@ -273,7 +273,7 @@ function scr_update_unit_mobility_item(new_mobility_item, from_armoury = true, t
   	if (from_armoury && new_mobility_item!="" && !arti){
   		if (scr_item_count(new_mobility_item, quality)>0){
 			var exp_require = gear_weapon_data("weapon", new_mobility_item, "req_exp", false, quality);
-  			if (exp_require>experience()){
+  			if (exp_require>experience){
   				return "exp_low";
   			} 	  				  			
 	   		quality=scr_add_item(new_mobility_item,-1, quality);

--- a/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
+++ b/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
@@ -215,7 +215,7 @@ function scr_marine_spawn_age(){
 }
 function scr_marine_spawn_armour(){
 	var _age = age();
-	var _exp = experience();
+	var _exp = experience;
 	var _total_score = _age + _exp;
 
 	var armour_weighted_lists = {
@@ -286,7 +286,7 @@ function scr_marine_spawn_armour(){
 }
 function scr_marine_game_spawn_constructions(){
 	roll_age();
-	roll_experience();
+	roll_experience;
 	assign_reactionary_traits();
 	roll_armour();
 	
@@ -450,13 +450,13 @@ function scr_marine_game_spawn_constructions(){
 		add_trait("tyrannic_vet");
 		bionic_count+=irandom(2);
 	};		
-	if (irandom(399-experience()) == 0){
+	if (irandom(399-experience) == 0){
 		add_trait("still_standing");
 	};
-	if (irandom(399-experience()) == 0){
+	if (irandom(399-experience) == 0){
 		add_trait("beast_slayer");
 	};		
-	if (irandom(499-experience())==0){
+	if (irandom(499-experience)==0){
 		add_trait("lone_survivor");
 	}
 	for(var i=0;i<bionic_count;i++){

--- a/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
+++ b/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
@@ -286,7 +286,7 @@ function scr_marine_spawn_armour(){
 }
 function scr_marine_game_spawn_constructions(){
 	roll_age();
-	roll_experience;
+	roll_experience();
 	assign_reactionary_traits();
 	roll_armour();
 	


### PR DESCRIPTION
https://discord.com/channels/714022226810372107/1120687959365128243/threads/1299832338531876894
attempts to solve this crash by deprecating `the obj_ini.experience` in favour of a built in to the unit struct experience value. This invloves changing all reference of `obj_ini.experience[co][id]` to `unit.experience` and all values of `unit.experience()` also to `unit.experience()`, further it requires all values of `obj_ini.experience[co][id] = <value>` to be restructured to `unit.add_exp(<value>)` or `unit.update_experience(<value>)`.
This is net better as it should remedy the crash and also means stat growth is supported across all exp gains