### PR TITLE
refactor: progenitor enumerator

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -938,7 +938,7 @@ trade_mnum[4]=0;
 requisition=500;
 if (instance_exists(obj_ini)){
     if (
-        (obj_ini.progenitor == PROGENITOR.DARK_ANGELS) &&
+        (obj_ini.progenitor == PROGENITOR.NONE) &&
         (global.chapter_name != "Doom Benefactors")
     ) {
         requisition=2000;

--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -937,7 +937,12 @@ trade_mnum[4]=0;
 // ** Sets up starting requisition **
 requisition=500;
 if (instance_exists(obj_ini)){
-    if (obj_ini.progenitor==0) /*and (obj_creation.custom=0)*/ and (global.chapter_name!="Doom Benefactors") then requisition=2000;
+    if (
+        (obj_ini.progenitor == PROGENITOR.DARK_ANGELS) &&
+        (global.chapter_name != "Doom Benefactors")
+    ) {
+        requisition=2000;
+    }
 }
 if (is_test_map==true) then requisition=50000;
 // ** Sets income **
@@ -1279,7 +1284,7 @@ trim=0;
 // ** Sets up names, progenitor, successors and mutations ** 
 adept_name="";
 recruiter_name="";
-progenitor="";
+progenitor=PROGENITOR.NONE;
 successor_chapters=0;
 mutation="";
 

--- a/objects/obj_event/Alarm_0.gml
+++ b/objects/obj_event/Alarm_0.gml
@@ -39,10 +39,18 @@ if (obj_controller.fest_type="Great Feast"){
     }
     
     
-    if (obj_controller.fest_feature2=1){
-        var boozer_type;boozer_type=1;
-        if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then boozer_type=2;
-        if (global.chapter_name="Blood Angels") or (obj_ini.progenitor=5) then boozer_type=3;
+    if (obj_controller.fest_feature2 == 1){
+        var boozer_type = 1;
+        if (
+            (global.chapter_name="Space Wolves") || (obj_ini.progenitor == PROGENITOR.SPACE_WOLVES)
+        ) {
+            boozer_type = 2;
+        }
+        if (
+            (global.chapter_name="Blood Angels") || (obj_ini.progenitor == PROGENITOR.BLOOD_ANGELS)
+        ) {
+            boozer_type = 3;
+        }
         
         if (boozer_type=1) then intro+="  Also provided is well-aged, finely distilled Amasec.";
         if (boozer_type=2) and (global.chapter_name!="Space Wolves") then intro+="  Also provided is Fenrir-imported Mjod, favored by the sons of Russ.";

--- a/objects/obj_event/Step_0.gml
+++ b/objects/obj_event/Step_0.gml
@@ -163,8 +163,16 @@ if (ticked=1){// Select a random marine and have them perform an action
             if (dice3<=min(75,(((obj_controller.fest_drugses*10)-10)+mod3)/rep3)) and (obj_controller.fest_feature3>0) then activity="drugs";
             if (dice2<=min(75,(((obj_controller.fest_boozes*20)-10)+mod2)/rep2)) and (obj_controller.fest_feature2>0) then activity="drink";
             if (dice1<=min(75,(((obj_controller.fest_feasts*30))+mod1)/rep1)) and (obj_controller.fest_feature1>0) then activity="eat";
-            if ((global.chapter_name="Space Wolves") or (obj_ini.progenitor=3)) and (obj_controller.fest_feature2>0) and (activity!="drink"){
-                rando=choose(1,1,2);if (rando=2) then activity="drink";
+            if (
+                (
+                    (global.chapter_name="Space Wolves") ||
+                    (obj_ini.progenitor == PROGENITOR.SPACE_WOLVES)
+                ) &&
+                (obj_controller.fest_feature2 > 0) &&
+                activity != "drink"
+            ) {
+                rando=choose(1,1,2);
+                if (rando=2) { activity="drink"; }
             }
             rando=choose(1,2,3,4,5,6,7,8,9,10);
             if (rando>=8) then activity="talk";
@@ -190,7 +198,7 @@ if (ticked=1){// Select a random marine and have them perform an action
     }
     if (activity="eat"){
         var eater_type=1;
-        if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then eater_type=2;
+        if (global.chapter_name="Space Wolves" || obj_ini.progenitor == PROGENITOR.SPACE_WOLVES) { eater_type=2; }
         
         if (stage=5) and (eater_type=1){rando=choose(1,2,3);
             if (rando=1) then textt=unit.name_role()+" digs into the food and begins to eat.";
@@ -231,8 +239,8 @@ if (ticked=1){// Select a random marine and have them perform an action
     }
     if (activity="drink"){
         var eater_type;eater_type=1;
-        if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then eater_type=2;
-        if (global.chapter_name="Blood Angels") or (obj_ini.progenitor=5) then eater_type=3;
+        if (global.chapter_name="Space Wolves" || obj_ini.progenitor == PROGENITOR.SPACE_WOLVES) then eater_type=2;
+        if (global.chapter_name="Blood Angels" || obj_ini.progenitor == PROGENITOR.BLOOD_ANGELS) then eater_type=3;
         
         if (eater_type=1){
             if (attend_drunk[ide]<=0) then textt=unit.name_role()+" hails a serf and has "+choose("him","her")+" pour some Amasec.";

--- a/objects/obj_ini/Create_0.gml
+++ b/objects/obj_ini/Create_0.gml
@@ -15,7 +15,7 @@ strin="";
 strin2="";
 tolerant=0;
 companies=10;
-progenitor=0;
+progenitor=PROGENITOR.NONE;
 aspirant_trial = 0;
 
 load_to_ships=[2,0,0];

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -539,7 +539,7 @@ function scr_draw_unit_image(_background=false){
             unit_specialization=0;
             if (unit_role=obj_ini.role[100,14]) then unit_specialization == UnitSpecialization.Chaplain;// Chaplain
             if (unit_role=obj_ini.role[100,15]) then unit_specialization == UnitSpecialization.Apothecary;// Apothecary
-            if (unit_role=obj_ini.role[100,15]) and ((unit_chapter="Blood Angels" || obj_ini.progenitor==5)) then unit_specialization=4;// Sanguinary
+            if (unit_role=obj_ini.role[100,15]) and ((unit_chapter="Blood Angels" || obj_ini.progenitor==PROGENITOR.BLOOD_ANGELS)) then unit_specialization=4;// Sanguinary
             if (unit_role=obj_ini.role[100,16]) then unit_specialization == UnitSpecialization.Techmarine;// Techmarine
             if (unit_role=obj_ini.role[100,17]) then unit_specialization == UnitSpecialization.Librarian;// Librarian
             */
@@ -699,15 +699,32 @@ function scr_draw_unit_image(_background=false){
         
             //Rejoice!
             // draw_sprite(spr_marine_base,img,x_surface_offset,y_surface_offset);
-            var clothing_style=3;
-            if (unit_progenitor=="Dark Angels")  {clothing_style=0;}
-            else if (unit_progenitor=="White Scars")  {clothing_style=1; }
-            else if (unit_progenitor=="Space Wolves")  {clothing_style=2;}
-            else if (unit_progenitor=="Imperial Fists")  {clothing_style=0;}
-            else if (unit_progenitor=="Iron Hands" ) { clothing_style=0;}
-            else if (unit_progenitor=="Salamanders" )  {clothing_style=4;}
-            else if (unit_progenitor=="Raven Guard")  {clothing_style=0;}
-            else if (unit_progenitor=="Doom Benefactors")  {clothing_style=4;}
+            var clothing_style = 3;
+
+            if (global.chapter_name == "Doom Benefactors") {
+                clothing_style = 4;
+            } else {
+                switch (obj_ini.progenitor) {
+                    case PROGENITOR.DARK_ANGELS:
+                    case PROGENITOR.IMPERIAL_FISTS:
+                    case PROGENITOR.IRON_HANDS:
+                    case PROGENITOR.RAVEN_GUARD:
+                        clothing_style = 0;
+                        break;
+
+                    case PROGENITOR.WHITE_SCARS:
+                        clothing_style = 1;
+                        break;
+
+                    case PROGENITOR.SPACE_WOLVES:
+                        clothing_style = 2;
+                        break;
+
+                    case PROGENITOR.SALAMANDERS:
+                        clothing_style = 4;
+                        break;
+                }
+            }
         
             // Determine Sprite
             if (skull_mask=-50) then skull_mask=1;
@@ -827,7 +844,6 @@ function scr_draw_unit_image(_background=false){
             
                 if (skin_color!=6) then draw_sprite(spr_clothing_colors,clothing_style,x_surface_offset,y_surface_offset);
             } else { 
-
                 var specific_helm = false;
                 var helm_draw=[0,0];
                 if (armour_type == ArmourType.Scout){
@@ -844,7 +860,7 @@ function scr_draw_unit_image(_background=false){
                     complex_set = get_complex_set("mk3");
                     complex_livery = true;
                     specific_helm = spr_generic_sgt_mk3;
-                    if (unit_progenitor=="Dark Angels"){
+                    if (unit_progenitor == PROGENITOR.DARK_ANGELS){
                         complex_livery = false;
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
@@ -870,7 +886,7 @@ function scr_draw_unit_image(_background=false){
                             armour_bypass=true;
                         }*/                      
                     }
-                    if (unit_progenitor=="Dark Angels"){
+                    if (unit_progenitor == PROGENITOR.DARK_ANGELS){
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
                             // specific_armour_sprite = spr_da_mk4;
@@ -887,7 +903,7 @@ function scr_draw_unit_image(_background=false){
                     complex_livery = true;
                     //TODO sort this mess out streamline system somehow
                     specific_helm = spr_generic_sgt_mk5;
-                    if (unit_progenitor=="Dark Angels"){
+                    if (unit_progenitor == PROGENITOR.DARK_ANGELS){
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
                             // specific_armour_sprite = spr_da_mk5;
@@ -904,7 +920,7 @@ function scr_draw_unit_image(_background=false){
                     complex_livery = true;
                     specific_armour_sprite = spr_beakie_colors;
                     specific_helm = spr_generic_sgt_mk6;
-                    if (unit_progenitor=="Dark Angels"){
+                    if (obj_ini.progenitor == PROGENITOR.DARK_ANGELS){
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
                             complex_livery = false;
@@ -921,7 +937,7 @@ function scr_draw_unit_image(_background=false){
                     complex_set = get_complex_set("mk7");
                     complex_livery = true;
                     specific_helm = spr_generic_sgt_mk7;
-                    if (unit_progenitor=="Dark Angels"){
+                    if (obj_ini.progenitor == PROGENITOR.DARK_ANGELS){
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
                             // specific_armour_sprite = spr_da_mk7;
@@ -936,7 +952,7 @@ function scr_draw_unit_image(_background=false){
                     specific_helm = spr_generic_sgt_mk8;
                     specific_armour_sprite = spr_mk8_colors;
                     complex_livery = true;
-                    if (unit_progenitor=="Dark Angels"){
+                    if (unit_progenitor == PROGENITOR.DARK_ANGELS) {
                         specific_helm = false;
                         if (unit_role==obj_ini.role[100][Role.CAPTAIN]){
                             // specific_armour_sprite = spr_da_mk8;
@@ -1490,7 +1506,7 @@ function scr_draw_unit_image(_background=false){
 				yep=0;
                 if (array_contains(obj_ini.adv,"Tech-Brothers")){
                     helm_ii=2;
-                }else if (array_contains(obj_ini.adv,"Never Forgive") || obj_ini.progenitor==1){
+                }else if (array_contains(obj_ini.adv, "Never Forgive") || obj_ini.progenitor == PROGENITOR.DARK_ANGELS){
                     helm_ii=3;
                 } else if (reverent_guardians) {
                     helm_ii=4;
@@ -1499,7 +1515,11 @@ function scr_draw_unit_image(_background=false){
 			}
 
             // Drawing Robes
-            if (unit_chapter == "Dark Angels" or obj_ini.progenitor == 0) && (unit_role != obj_ini.role[100][Role.SERGEANT]) && (unit_role != obj_ini.role[100][Role.VETERAN_SERGEANT]){
+            if (
+                ((unit_chapter == "Dark Angels") || (obj_ini.progenitor == PROGENITOR.DARK_ANGELS)) &&
+                (unit_role != obj_ini.role[100][Role.SERGEANT]) &&
+                (unit_role != obj_ini.role[100][Role.VETERAN_SERGEANT])
+            ) {
                 robes_bypass = true;
                 robes_hood_bypass = true;
             }

--- a/scripts/scr_event_dudes/scr_event_dudes.gml
+++ b/scripts/scr_event_dudes/scr_event_dudes.gml
@@ -8,7 +8,7 @@ function scr_event_dudes(do_action, is_planet, system_name, location_id) {
 	*/
 
 	if (do_action=1){
-	    if (obj_ini.progenitor == PROGENITOR.DARK_ANGELS) {
+	    if (obj_ini.progenitor == PROGENITOR.NONE) {
 	        if (obj_controller.fest_feasts<2) then obj_controller.fest_feasts=2;
 	    }
 	    if ((global.chapter_name="Space Wolves") || (obj_ini.progenitor == PROGENITOR.SPACE_WOLVES)) {

--- a/scripts/scr_event_dudes/scr_event_dudes.gml
+++ b/scripts/scr_event_dudes/scr_event_dudes.gml
@@ -8,14 +8,14 @@ function scr_event_dudes(do_action, is_planet, system_name, location_id) {
 	*/
 
 	if (do_action=1){
-	    if (obj_ini.progenitor=0){
+	    if (obj_ini.progenitor == PROGENITOR.DARK_ANGELS) {
 	        if (obj_controller.fest_feasts<2) then obj_controller.fest_feasts=2;
 	    }
-	    if ((global.chapter_name="Space Wolves") or (obj_ini.progenitor=3)){
+	    if ((global.chapter_name="Space Wolves") || (obj_ini.progenitor == PROGENITOR.SPACE_WOLVES)) {
 	        if (obj_controller.fest_feasts<10) then obj_controller.fest_feasts=10;
 	        if (obj_controller.fest_boozes<10) then obj_controller.fest_boozes=10;
 	    }
-	    if ((global.chapter_name="Blood Angels") or (obj_ini.progenitor=5)){
+	    if ((global.chapter_name="Blood Angels") || (obj_ini.progenitor == PROGENITOR.BLOOD_ANGELS)) {
 	        if (obj_controller.fest_boozes<3) then obj_controller.fest_boozes=3;
 	    }
 	}

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -19,7 +19,21 @@ enum Role {
 	VETERAN_SERGEANT = 19
 }
 
-function complex_livery_default(){
+enum PROGENITOR {
+    NONE,
+    DARK_ANGELS,
+    WHITE_SCARS,
+    SPACE_WOLVES,
+    IMPERIAL_FISTS,
+    BLOOD_ANGELS,
+    IRON_HANDS,
+    ULTRAMARINES,
+    SALAMANDERS,
+    RAVEN_GUARD,
+    RANDOM,
+}
+
+function complex_livery_default() {
 	return {
 		sgt : {
 			helm_pattern:3,
@@ -47,413 +61,434 @@ function complex_livery_default(){
 			helm_primary : 0,
 			helm_secondary : 0,
 			helm_detail : 0,
-			helm_lens : 0,			
-		}		
+			helm_lens : 0,
+		}
 	};
 }
-function progenitor_livery(chapter, specific="none"){
-	//default
-	var livery_data = complex_livery_default();	
-	//custom for chapters
-	if (chapter=="Space Wolves"){
-		livery_data = {
-			sgt : {
-				helm_pattern:3,
-				helm_primary :Colors.Fenrisian_Grey,
-				helm_secondary : Colors.Red,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:3,
-				helm_primary : Colors.Fenrisian_Grey,
-				helm_secondary : Colors.Black,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:3,
-				helm_primary : Colors.Fenrisian_Grey,
-				helm_secondary : Colors.Black,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.White,
-				helm_lens : Colors.Red,			
-			}		
-		}
-	}else if (chapter == "Dark Angels"){
-		livery_data = {
-			sgt: {
-				helm_pattern: 0,
-				helm_primary: obj_creation.main_color,
-				helm_secondary: obj_creation.main_color,
-				helm_detail: obj_creation.main_trim,
-				helm_lens: obj_creation.lens_color,
-			},
-			vet_sgt: {
-				helm_pattern: 1,
-				helm_primary: obj_creation.main_color,
-				helm_secondary: obj_creation.main_color,
-				helm_detail: obj_creation.main_trim,
-				helm_lens: obj_creation.lens_color,
-			},
-			captain: {
-				helm_pattern: 0,
-				helm_primary: obj_creation.main_color,
-				helm_secondary: obj_creation.main_color,
-				helm_detail: obj_creation.main_trim,
-				helm_lens: obj_creation.lens_color,
-			},
-			veteran: {
-				helm_pattern: 0,
-				helm_primary: obj_creation.main_color,
-				helm_secondary: obj_creation.main_color,
-				helm_detail: obj_creation.main_trim,
-				helm_lens: obj_creation.lens_color,
-			}
-		}
-	}else if (chapter=="Raven Guard"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary :Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Green,			
-			}		
-		}
-	}else if (chapter=="Salamanders"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary :Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Red,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.Firedrake_Green,
-				helm_secondary : Colors.Firedrake_Green,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Green,			
-			}		
-		}
-	}else if (chapter=="White Scars"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary :Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.Red,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.White,
-				helm_lens : Colors.Green,			
-			}		
-		}
-	}else if (chapter=="Iron Hands"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary :Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : 0,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Green,			
-			}		
-		}
-	}else if (chapter=="Ultramarines"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary : Colors.Red,
-				helm_secondary : Colors.Red,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Red,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.Dark_Ultramarine,
-				helm_secondary : Colors.Dark_Ultramarine,
-				helm_detail : Colors.Dark_Ultramarine,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.White,
-				helm_lens : Colors.Red,			
-			}				
-		}
-	}else if (chapter=="Imperial Fists"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.Dark_Gold,
-				helm_secondary : Colors.Dark_Gold,
-				helm_detail : Colors.Dark_Gold,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.Red,
-				helm_secondary : Colors.Red,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,			
-			}				
-		} 
-	}else if (chapter=="Blood Angels"){
-		livery_data = {
-			sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Sanguine_Red,
-				helm_secondary : Colors.Sanguine_Red,
-				helm_detail : Colors.Lighter_Black,
-				helm_lens : Colors.Lime,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Gold,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Gold,
-				helm_lens : Colors.Lime,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.Sanguine_Red,
-				helm_secondary : Colors.Sanguine_Red,
-				helm_detail : Colors.Gold,
-				helm_lens : Colors.Lime,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.Gold,
-				helm_secondary : Colors.Gold,
-				helm_detail : Colors.Gold,
-				helm_lens : Colors.Lime,			
-			}				
-		}
-	}else if (global.chapter_name=="Blood Ravens"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Lime,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Lime,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : Colors.Copper,
-				helm_secondary : Colors.Copper,
-				helm_detail : Colors.Copper,
-				helm_lens : Colors.Lime,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.White,
-				helm_lens : Colors.Lime,			
-			}				
-		}
-	}else if (global.chapter_name=="Minotaurs"){
-		livery_data = {
-			sgt : {
-				helm_pattern:0,
-				helm_primary : Colors.Black,
-				helm_secondary : Colors.Black,
-				helm_detail : Colors.Black,
-				helm_lens : Colors.Red,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : obj_creation.main_color,
-				helm_secondary : Colors.Black,
-				helm_detail : obj_creation.main_color,
-				helm_lens : Colors.Red,
-			},
-			captain : {
-				helm_pattern:2,
-				helm_primary : obj_creation.main_color,
-				helm_secondary : Colors.Dark_Red,
-				helm_detail : obj_creation.main_color,
-				helm_lens : Colors.Red,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : obj_creation.main_color,
-				helm_secondary : obj_creation.main_color,
-				helm_detail : obj_creation.main_color,
-				helm_lens : Colors.Red,			
-			}				
-		}
-	}else {
-		livery_data =  {
-			sgt : {
-				helm_pattern:0,
-				helm_primary : Colors.Red,
-				helm_secondary : Colors.Red,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			vet_sgt : {
-				helm_pattern:1,
-				helm_primary : Colors.Red,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.Red,
-				helm_lens : Colors.Green,
-			},
-			captain : {
-				helm_pattern:0,
-				helm_primary : obj_creation.main_color,
-				helm_secondary : obj_creation.main_color,
-				helm_detail : obj_creation.main_color,
-				helm_lens : obj_creation.lens_color,
-			},
-			veteran : {
-				helm_pattern:0,
-				helm_primary : Colors.White,
-				helm_secondary : Colors.White,
-				helm_detail : Colors.White,
-				helm_lens : Colors.Red,			
-			}			
-		}	
-	}
-	if (specific=="none"){
-		return livery_data;
-	} else {
-		return livery_data[$ specific];
-	}
+
+function select_livery_data(livery_data, specific) {
+    // Return specific livery data if requested
+    if (specific == "none") {
+        return livery_data;
+    } else {
+        return livery_data[$ specific];
+    }
 }
 
-function progenitor_map(){
-	var founding_chapters = [
-		"",
-		"Dark Angels",
-		"White Scars",
-		"Space Wolves",
-		"Imperial Fists",
-		"Blood Angels",
-		"Iron Hands",
-		"Ultramarines",
-		"Salamanders",
-		"Raven Guard"
-	]
-	for (i=1;i<10;i++){
-		if (global.chapter_name==founding_chapters[i] || obj_ini.progenitor==i){
-			return founding_chapters[i];
-		}
-	}
-	return "";
+function progenitor_livery(progenitor, specific = "none") {
+    var livery_data;
+
+    var name_selected = true;
+    switch (global.chapter_name) {
+        case "Blood Ravens":
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Lime,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Lime,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Copper,
+                    helm_secondary: Colors.Copper,
+                    helm_detail: Colors.Copper,
+                    helm_lens: Colors.Lime,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.White,
+                    helm_lens: Colors.Lime,
+                },
+            };
+            break;
+
+        case "Minotaurs":
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: Colors.Black,
+                    helm_detail: obj_creation.main_color,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 2,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: Colors.Dark_Red,
+                    helm_detail: obj_creation.main_color,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.main_color,
+                    helm_lens: Colors.Red,
+                },
+            };
+            break;
+
+        default:
+            name_selected = false;
+            break;
+    }
+
+    if (name_selected) {
+        return select_livery_data(livery_data, specific);
+    }
+
+    switch (progenitor) {
+        case PROGENITOR.SPACE_WOLVES:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 3,
+                    helm_primary: Colors.Fenrisian_Grey,
+                    helm_secondary: Colors.Red,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 3,
+                    helm_primary: Colors.Fenrisian_Grey,
+                    helm_secondary: Colors.Black,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 3,
+                    helm_primary: Colors.Fenrisian_Grey,
+                    helm_secondary: Colors.Black,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.White,
+                    helm_lens: Colors.Red,
+                },
+            };
+            break;
+
+        case PROGENITOR.DARK_ANGELS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.trim_color,
+                    helm_lens: obj_creation.lens_color,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.trim_color,
+                    helm_lens: obj_creation.lens_color,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.trim_color,
+                    helm_lens: obj_creation.lens_color,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.trim_color,
+                    helm_lens: obj_creation.lens_color,
+                },
+            };
+            break;
+
+        case PROGENITOR.RAVEN_GUARD:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Green,
+                },
+            };
+            break;
+
+        case PROGENITOR.SALAMANDERS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Red,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Firedrake_Green,
+                    helm_secondary: Colors.Firedrake_Green,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Green,
+                },
+            };
+            break;
+
+        case PROGENITOR.WHITE_SCARS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.Red,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.White,
+                    helm_lens: Colors.Green,
+                },
+            };
+            break;
+
+        case PROGENITOR.IRON_HANDS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: 0,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Black,
+                    helm_lens: Colors.Green,
+                },
+            };
+            break;
+
+        case PROGENITOR.ULTRAMARINES:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Red,
+                    helm_secondary: Colors.Red,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Red,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Dark_Ultramarine,
+                    helm_secondary: Colors.Dark_Ultramarine,
+                    helm_detail: Colors.Dark_Ultramarine,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.White,
+                    helm_lens: Colors.Red,
+                },
+            };
+            break;
+
+        case PROGENITOR.IMPERIAL_FISTS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Black,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Dark_Gold,
+                    helm_secondary: Colors.Dark_Gold,
+                    helm_detail: Colors.Dark_Gold,
+                    helm_lens: Colors.Red,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Red,
+                    helm_secondary: Colors.Red,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+            };
+            break;
+
+        case PROGENITOR.BLOOD_ANGELS:
+            livery_data = {
+                sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Sanguine_Red,
+                    helm_secondary: Colors.Sanguine_Red,
+                    helm_detail: Colors.Lighter_Black,
+                    helm_lens: Colors.Lime,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Gold,
+                    helm_secondary: Colors.Black,
+                    helm_detail: Colors.Gold,
+                    helm_lens: Colors.Lime,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Sanguine_Red,
+                    helm_secondary: Colors.Sanguine_Red,
+                    helm_detail: Colors.Gold,
+                    helm_lens: Colors.Lime,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Gold,
+                    helm_secondary: Colors.Gold,
+                    helm_detail: Colors.Gold,
+                    helm_lens: Colors.Lime,
+                },
+            };
+            break;
+
+        default:
+            // Not a named chapter or progenitor we have data for.
+            // before this refactor, this was the true default, not complex_livery_default
+            livery_data = {
+                sgt: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.Red,
+                    helm_secondary: Colors.Red,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                vet_sgt: {
+                    helm_pattern: 1,
+                    helm_primary: Colors.Red,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.Red,
+                    helm_lens: Colors.Green,
+                },
+                captain: {
+                    helm_pattern: 0,
+                    helm_primary: obj_creation.main_color,
+                    helm_secondary: obj_creation.main_color,
+                    helm_detail: obj_creation.main_color,
+                    helm_lens: obj_creation.lens_color,
+                },
+                veteran: {
+                    helm_pattern: 0,
+                    helm_primary: Colors.White,
+                    helm_secondary: Colors.White,
+                    helm_detail: Colors.White,
+                    helm_lens: Colors.Red,
+                },
+            };
+            break;
+    }
+    return select_livery_data(livery_data, specific);
 }
 
 function trial_map(trial_name){
@@ -524,29 +559,28 @@ function scr_initialize_custom() {
 	global.game_seed = floor(random(99999999)) + string_to_integer(global.chapter_name) + string_to_integer(obj_creation.chapter_master_name);
 
 
-	if (progenitor = 10) { // Pretty sure that's random?
-		var legions = ["Dark Angels",
-			"Emperor's Children",
-			"Iron Warriors",
-			"White Scars",
-			"Space Wolves",
-			"Imperial Fists",
-			"Night Lords",
-			"Blood Angels",
-			"Iron Hands",
-			"World Eaters",
-			"Ultramarines",
-			"Death Guard",
-			"Thousand Sons",
-			"Black Legion",
-			"Word Bearers",
-			"Salamanders",
-			"Raven Guard",
-			"Alpha Legion"
-		]
-		global.founding_secret = legions[irandom(array_length(legions))];
-	}
-
+    if (progenitor == PROGENITOR.RANDOM) {
+        global.founding_secret = array_random_element([
+            "Dark Angels",
+            "Emperor's Children",
+            "Iron Warriors",
+            "White Scars",
+            "Space Wolves",
+            "Imperial Fists",
+            "Night Lords",
+            "Blood Angels",
+            "Iron Hands",
+            "World Eaters",
+            "Ultramarines",
+            "Death Guard",
+            "Thousand Sons",
+            "Black Legion",
+            "Word Bearers",
+            "Salamanders",
+            "Raven Guard",
+            "Alpha Legion"
+        ]);
+    }
 
 
 	company_title = [
@@ -945,7 +979,7 @@ function scr_initialize_custom() {
 		apothecary += 7;
 	}
 	
-	if ((progenitor >= 1) and(progenitor <= 10)) or((global.chapter_name = "Doom Benefactors") and(obj_creation.custom = 0)) {
+	if ((progenitor > PROGENITOR.NONE) && (progenitor < PROGENITOR.RANDOM) || (global.chapter_name = "Doom Benefactors") && (obj_creation.custom == 0)) {
 		if (obj_creation.strength <= 4) then ninth = 0;
 		if (obj_creation.strength <= 3) then eighth = 0;
 		if (obj_creation.strength <= 2) then seventh = 0;
@@ -1164,14 +1198,15 @@ function scr_initialize_custom() {
 		}
 	}
 	complex_livery_data = obj_creation.complex_livery_data;
-	var complex_type = ["sgt", "vet_sgt", "captain", "veteran"];
-	for (var i=0;i<array_length(complex_type);i++){
-		with (complex_livery_data[$ complex_type[i]]){
-			if (helm_primary==0 && helm_secondary==0 && helm_lens==0){
-				obj_ini.complex_livery_data[$ complex_type[i]] = progenitor_livery(progenitor_map(), complex_type[i]);
-			}
-		}
-	}
+    var complex_type = ["sgt", "vet_sgt", "captain", "veteran"];
+    for (var i = 0; i < array_length(complex_type); i++) {
+        with (complex_livery_data[$ complex_type[i]]) {
+            if (helm_primary == 0 && helm_secondary == 0 && helm_lens == 0) {
+                obj_ini.complex_livery_data[$ complex_type[i]] = progenitor_livery(obj_ini.progenitor, complex_type[i]);
+            }
+        }
+    }
+
 
 	/*main_color=obj_creation.main_color;
 	secondary_color=obj_creation.secondary_color;
@@ -1409,10 +1444,10 @@ function scr_initialize_custom() {
 
 	*/
 	var squad_name = "Squad";
-	if (global.chapter_name == "Space Wolves" || obj_ini.progenitor == 3) {
+	if (global.chapter_name == "Space Wolves" || obj_ini.progenitor == PROGENITOR.SPACE_WOLVES) {
 		squad_name = "Pack";
 	}
-	if (global.chapter_name == "Iron Hands" || obj_ini.progenitor == 6) {
+	if (global.chapter_name == "Iron Hands" || obj_ini.progenitor == PROGENITOR.IRON_HANDS) {
 		squad_name = "Clave";
 	}
 	if(obj_creation.use_chapter_object){
@@ -2906,7 +2941,7 @@ function scr_initialize_custom() {
 		if (obj_creation.adv[o] = "Brothers, All") then chapter_option = 1;
 	}
 	if (chapter_option = 1) then _honour_guard_count += 10;
-	if (progenitor = 0) and (obj_creation.custom = 0) then _honour_guard_count += 6;
+	if (progenitor == PROGENITOR.DARK_ANGELS && obj_creation.custom = 0) { _honour_guard_count += 6; }
 	if (_honour_guard_count == 0) {
 		_honour_guard_count = 3
 	}

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1201,7 +1201,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					"technophobe", 
 					[99,98],
 					{
-						"progenitor":[6,[1000,999]],
+						"progenitor":[PROGENITOR.IRON_HANDS,[1000,999]],
 						recruit_world_type : [
 							["Ice", -5],
 							["Death", -2],
@@ -1275,7 +1275,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				],
 				["flesh_is_weak",[1000,999],{
 						chapter_name:["Iron Hands",[1000,600],"required"],
-						progenitor:[6,[1000,800],"required"],
+						progenitor:[PROGENITOR.IRON_HANDS,[1000,800],"required"],
 						recruit_world_type: [
 							["Forge", -300],
 							["Lava", -15],
@@ -1409,11 +1409,11 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 			}
 
 
-			if (global.chapter_name=="Space Wolves") or (obj_ini.progenitor=3) {
+			if (global.chapter_name=="Space Wolves") or (obj_ini.progenitor == PROGENITOR.SPACE_WOLVES) {
 				religion_sub_cult = "The Allfather";
-			} else if(global.chapter_name=="Salamanders") or (obj_ini.progenitor==8){
+			} else if(global.chapter_name=="Salamanders") or (obj_ini.progenitor == PROGENITOR.SALAMANDERS) {
 				religion_sub_cult = "The Promethean Cult";
-			} else if (global.chapter_name=="Iron Hands") or (obj_ini.progenitor=6){
+			} else if (global.chapter_name=="Iron Hands" || obj_ini.progenitor == PROGENITOR.IRON_HANDS) {
 				religion_sub_cult = "The Cult of Iron";
 			} 
 
@@ -1424,7 +1424,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 						body[$"head"].hood = 1;
 					}
 				}
-			}else if(global.chapter_name == "Dark Angels" || obj_ini.progenitor==1){
+			}else if(global.chapter_name == "Dark Angels" || obj_ini.progenitor == PROGENITOR.DARK_ANGELS){
 				body[$"torso"].robes = choose(0,0,0,1,2);
 				if (body[$"torso"].robes == 0 && irandom(1) == 0){
 					body[$"head"].hood = 1;

--- a/scripts/scr_purge_world/scr_purge_world.gml
+++ b/scripts/scr_purge_world/scr_purge_world.gml
@@ -209,12 +209,12 @@ function scr_purge_world(star, planet, action_type, action_score) {
 		if(scr_has_disadv("Shitty Luck")) then chance+=20;
 
 	    // Size
-	    if (action_score>5) and (action_score<=10) then siz_penalty=5;
-	    if (action_score>10) and (action_score<=20) then siz_penalty=20;
-	    if (action_score>20) and (action_score<=50) then siz_penalty=30;
-	    if (action_score>50) and (action_score<=100) then siz_penalty=50;
-	    if (action_score>100) and (action_score<=200) then siz_penalty=75;
-	    if (action_score>200) then siz_penalty=125;
+	    if ((action_score > 5) && (action_score <= 10)) { siz_penalty = 5; }
+	    if ((action_score > 10) && (action_score <= 20)) { siz_penalty = 20; }
+	    if ((action_score > 20) && (action_score <= 50)) { siz_penalty = 30; }
+	    if ((action_score > 50) && (action_score <= 100)) { siz_penalty = 50; }
+	    if ((action_score > 100) && (action_score <= 200)) { siz_penalty = 75; }
+	    if (action_score > 200) { siz_penalty = 125; }
 
 	    // Ambushers go!
 	    if (ambush=true) then chance=round(chance/2);
@@ -224,8 +224,8 @@ function scr_purge_world(star, planet, action_type, action_score) {
 	    txt+="Once the time is right their target is ambushed "+choose("in their home","in the streets","while driving","taking a piss")+" and tranquilized.  ";
     
 		if(scr_has_disadv("Never Forgive")) then spec1=1;
-	    if (global.chapter_name="Space Wolves") or (obj_ini.progenitor=3) then spec1=3;
-	    if (global.chapter_name="Iron Hands") or (obj_ini.progenitor=6) then spec1=6;
+	    if (global.chapter_name="Space Wolves" || obj_ini.progenitor == PROGENITOR.SPACE_WOLVES) { spec1=3; }
+	    if (global.chapter_name="Iron Hands" || obj_ini.progenitor == PROGENITOR.IRON_HANDS) { spec1=6; }
 	    if (obj_ini.omophagea=1) then spec1=choose(spec1,20);
     
 	    if (spec1=1) then txt+="They are brought to the already-prepared facilities for Fallen, tortured to make "+string(choose("him","him","her"))+" appear a heretic, and then incinerated.  ";

--- a/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
+++ b/scripts/scr_unit_spawn_functions/scr_unit_spawn_functions.gml
@@ -363,7 +363,11 @@ function scr_marine_game_spawn_constructions(){
 			} else {
 				bionic_count = choose(1,1,1,2,3)
 			}
-			if ((global.chapter_name == "Iron Hands" || obj_ini.progenitor = 6 || array_contains(obj_ini.dis, "Tech-Heresy"))) {
+			if (
+                (global.chapter_name == "Iron Hands") ||
+                (obj_ini.progenitor = PROGENITOR.IRON_HANDS) ||
+                array_contains(obj_ini.dis, "Tech-Heresy")
+            ) {
 				add_bionics("right_arm", "standard", false);
 				bionic_count = choose(6, 6, 7, 7, 7, 8, 9);
 				add_trait("flesh_is_weak");
@@ -397,7 +401,7 @@ function scr_marine_game_spawn_constructions(){
 				if (irandom(2) == 0) {
 					add_trait("crafter");
 				}
-			} else if (obj_ini.progenitor == 8 || obj_ini.progenitor == 6) {
+			} else if (obj_ini.progenitor == PROGENITOR.SALAMANDERS || obj_ini.progenitor == PROGENITOR.IRON_HANDS) {
 				technology += 2;
 				if (irandom(4) == 0) {
 					add_trait("crafter");


### PR DESCRIPTION
This PR refactors progenitor-related values, replacing magic numbers and strings with a new `PROGENITOR` enum for improved readability and maintainability.

- Added the `PROGENITOR` enum to represent known progenitors.
- Updated conditional logic across scripts to use `PROGENITOR` instead of hardcoded values, making the code more readable and less error-prone.

This change standardizes progenitor references, simplifies future additions, and eliminates ambiguity in the codebase.