### PR TITLE
Error logging edits

### DIFF
--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -3,7 +3,7 @@ function macros() {
 #macro MAX_STC_PER_SUBCATEGORY 6
 #macro DEFAULT_TOOLTIP_VIEW_OFFSET 32
 #macro DEFAULT_LINE_GAP -1
-#macro LINE_BREAK_92 "############################################################################################"
+#macro LB_92 "############################################################################################"
 
 	enum luck {
 		bad = -1,

--- a/scripts/scr_log/scr_log.gml
+++ b/scripts/scr_log/scr_log.gml
@@ -1,6 +1,6 @@
 function log_into_file(_message) {
     var _entry = string(_message);
-    var _date_time = string(current_day) + "-" + string (current_month) + "-" + string(current_year) + "_" + string(current_hour) + string(current_minute) + string(current_second);
+    var _date_time = $"{current_day}-{current_month}-{current_year}_{current_hour}{current_minute}{current_second}";
     var _log_file = file_text_open_write("ErrorLogs/" + $"error_log_{_date_time}.log");
 
     file_text_write_string(_log_file, _entry);
@@ -8,34 +8,41 @@ function log_into_file(_message) {
 }
 
 function try_and_report_loop(dev_marker="generic crash",func, turn_end=true, args=[], catch_custom=0, catch_args=[]){
-    #macro ERROR_MESSAGE $"The error log is automatically copied into your clipboard and a copy is created at: \nC:>Users>(UserName)>AppData>Local>ChapterMaster>ErrorLogs \n\nPlease, do the following: \n\n1) Create a bug report on the bug-report-forum in our 'Chapter Master Discord' server. \n\n2) Press CTRL+V to paste the error log into the bug report. \n\n3) If for some reason the error log wasn't pasted, find the location that is mentioned above and attach the latest (sort by time) error_log to your bug report. \n\n\nThank you :)"
+    #macro MSG_error_message $"The error log is automatically copied into your clipboard and a copy is created at: \nC:>Users>(UserName)>AppData>Local>ChapterMaster>ErrorLogs \n\nPlease, do the following: \n\n1) Create a bug report on the bug-report-forum in our 'Chapter Master Discord' server. \n\n2) Press CTRL+V to paste the error log into the bug report. \n\n3) Title your report by cutting and pasting the first line of the main message (it contains game version and file that caused the error). \n\n4) If for some reason the error log wasn't pasted, find the location that is mentioned above and attach the latest (sort by time) error_log to your bug report. In this case you can name your report as you wish. \n\n\nThank you :)"
 
     try{
         method_call(func,args);
     } catch (_exception){
-        var _popup_header = $"Your game just encountered an error ({dev_marker}) :(";
-        var _popup_message = ERROR_MESSAGE + "\n\n\nP.S. You can try to continue playing - if the error is not severe, the game should continue working, just try to avoid what caused it. \n\nBut it's recommended to wait for a response on the bug-report forum, otherwise you may make the issue worse.";
+        var _popup_header = $"Your game just encountered and caught an error ({dev_marker}) :(\n\n";
+        var _popup_message = MSG_error_message + "\n\n\n";
+        var _popup_ps = $"P.S. You can ALT-TAB and try to continue playing - if the error is not severe, the game should continue working, just try to avoid what caused it. \n\nBut it's recommended to wait for a response on the bug-report forum, otherwise you may make the issue worse.";
+        var _player_message = _popup_header + _popup_message + _popup_ps;
 
-        pip = instance_create(0,0,obj_popup);
-        pip.title = _popup_header;
-        pip.text = _popup_message;
-        pip.image = "debug"
+        var _formatted_stacktrace = format_stacktrace(_exception.stacktrace);
+        var _line_break = LB_92;
+        var _full_message = "";
+        var _report_title = $"[{GM_version}] {_exception.stacktrace[0]}\n";
 
-        var _formatted_stacktrace = "";
-        // Loop through the array
-        for (var i = 0; i < array_length(_exception.stacktrace); i++) {
-            _formatted_stacktrace += _exception.stacktrace[i];
-            // Add newline character
-            if (i < array_length(_exception.stacktrace) - 1) {
-                _formatted_stacktrace += "\n";
-            }
-        }
+        // var pip = instance_create(0,0,obj_popup);
+        // pip.title = _popup_header;
+        // pip.text = _popup_message;
+        // pip.image = "debug"
 
-        var _line_break = LINE_BREAK_92;
-        var _full_message = $"{_line_break}\nGame Version: {GM_version}\n\n{_exception.longMessage}\n\nIn:\n{_exception.script}\n\nStacktrace:\n{_formatted_stacktrace}\n{_line_break}";
+        // obj_popup doesn't work if multiple errors are encountered and/or it may get overwritten by other popups, it seems.
+        // scr_popup doesn't work if the error caused turn skip to get stuck.
+        // show_message() alt-tabs your game though, but there are no other options.
+        show_message(_player_message);
+
+        _full_message = $"{_line_break}\n";
+        _full_message += $"Caught Exception ({dev_marker})!\n";
+        _full_message += $"Game Version: {GM_version}\n\n";
+        _full_message += $"{_exception.longMessage}\n";
+        _full_message += $"Stacktrace:\n";
+        _full_message += $"{_formatted_stacktrace}\n";
+        _full_message += $"{_line_break}";
 
         log_into_file(_full_message);
-        clipboard_set_text(string(_full_message));
+        clipboard_set_text(_report_title + "```" + _full_message + "```");
     
         show_debug_message(_full_message);
 
@@ -46,28 +53,44 @@ function try_and_report_loop(dev_marker="generic crash",func, turn_end=true, arg
 }
 
 exception_unhandled_handler(function(_exception) {
+    var _full_message = "";
+    var _formatted_stacktrace = format_stacktrace(_exception.stacktrace);
+    var _line_break = LB_92;
+    var _popup_header = $"Your game just encountered a critical error :(\n\n";
+    var _player_message = _popup_header + MSG_error_message;
+    var _report_title = $"[{GM_version}] {_exception.stacktrace[0]}\n";
+
+    _full_message = $"{_line_break}\n";
+    _full_message += $"Unhandled Exception!\n";
+    _full_message += $"Game Version: {GM_version}\n\n";
+    _full_message += $"{_exception.longMessage}\n";
+    _full_message += $"Stacktrace:\n";
+    _full_message += $"{_formatted_stacktrace}\n";
+    _full_message += $"{_line_break}";
+
+    log_into_file(_full_message);
+    clipboard_set_text(_report_title + "```" +_full_message + "```");
+    show_message(_player_message);
+    
+    show_debug_message(_full_message);
+
+    return 0;
+});
+
+// Each stacktrace call on a newline
+function format_stacktrace(stacktrace) {
     var _formatted_stacktrace = "";
-    // Loop through the array
-    for (var i = 0; i < array_length(_exception.stacktrace); i++) {
-        _formatted_stacktrace += _exception.stacktrace[i];
-        // Add newline character
-        if (i < array_length(_exception.stacktrace) - 1) {
+
+    if (!is_array(stacktrace)) {
+        return;
+    }
+
+    for (var i = 0; i < array_length(stacktrace); i++) {
+        _formatted_stacktrace += stacktrace[i];
+        if (i < array_length(stacktrace) - 1) {
             _formatted_stacktrace += "\n";
         }
     }
 
-    var _line_break = LINE_BREAK_92;
-    var _full_message = $"{_line_break}\nGame Version: {GM_version}\n\n{_exception.longMessage}\n\nIn:\n{_exception.script}\n\nStacktrace:\n{_formatted_stacktrace}\n{_line_break}";
-
-    log_into_file(_full_message);
-    clipboard_set_text(_full_message);
-
-    show_debug_message(_line_break);
-    show_debug_message( "Unhandled exception!");
-    show_debug_message(_full_message);
-
-    var _player_message = ERROR_MESSAGE;
-    show_message(_player_message);
-
-    return 0;
-});
+    return _formatted_stacktrace;
+}

--- a/scripts/scr_log/scr_log.gml
+++ b/scripts/scr_log/scr_log.gml
@@ -42,7 +42,7 @@ function try_and_report_loop(dev_marker="generic crash",func, turn_end=true, arg
         _full_message += $"{_line_break}";
 
         log_into_file(_full_message);
-        clipboard_set_text(_report_title + "```" + _full_message + "```");
+        clipboard_set_text(_report_title + "```\n" + _full_message + "\n```");
     
         show_debug_message(_full_message);
 
@@ -69,7 +69,7 @@ exception_unhandled_handler(function(_exception) {
     _full_message += $"{_line_break}";
 
     log_into_file(_full_message);
-    clipboard_set_text(_report_title + "```" +_full_message + "```");
+    clipboard_set_text(_report_title + "```\n" +_full_message + "\n```");
     show_message(_player_message);
     
     show_debug_message(_full_message);


### PR DESCRIPTION
- Renamed a couple of macro, to follow the new naming convention.
- Refactored log file naming to use $ string concentration instead of +.
- Refactored and edited both `exception_unhandled_handler` error reporting and `try_and_report_loop`.
- Created a small function, to reduce verboseness, that formats stacktrace array into a multi-line string.
- Replaced usage of in-game popups to report minor errors by GM messages, with reasons explained in comments.
- Edited clipboard error message to contain markdown code formatting symbols and possible title for a bug report.
- Edited player message contents a little bit.

Example of the new clipboard message (MD symbols are included by code):

[0.9.4.1] gml_Script_anon@78@gml_Object_obj_turn_end_Alarm_0 (line 189)
```
############################################################################################
Caught Exception (battle alarm 0 loop)!
Game Version: 0.9.4.1

ERROR in
action number 1
of Alarm Event for alarm 0
for object obj_turn_end:


Variable obj_turn_end.didid(107350, -2147483648) not set before reading it.
 at gml_Script_anon@78@gml_Object_obj_turn_end_Alarm_0 (line 189) - dadda = didid;

Stacktrace:
gml_Script_anon@78@gml_Object_obj_turn_end_Alarm_0 (line 189)
gml_Script_try_and_report_loop (line 14)
gml_Object_obj_turn_end_Alarm_0 (line 3) - try_and_report_loop("battle alarm 0 loop", function(){
############################################################################################
```

And player message:
![image](https://github.com/user-attachments/assets/39083da4-18ae-4aad-98f8-3af8799bc582)