### PR TITLE
refactor: declare loop variables locally in for loops

### DIFF
--- a/objects/obj_fleet_select/Create_0.gml
+++ b/objects/obj_fleet_select/Create_0.gml
@@ -123,13 +123,13 @@ selection_window.inside_method = function(){
 	        if (posi<=escorts+frigates+capitals){
 	            name=ship_type[current_ship];
 	            if (string_width(name)*scale>179){
-	            	for (i=0;i<9;i++){
+	            	for (var i=0;i<9;i++){
 	            		if (string_width(name)*scale>179) then scale-=0.05;
 	            	}
 	            }
 	            if (scr_hit(xx+10,yy+y3,xx+width-10,yy+y3+18)){
 	                if (string_width(name)*scale>135){
-	                	for (i=0;i<9;i++){
+	                	for (var i=0;i<9;i++){
 	                		if (string_width(name)*scale>135) then scale-=0.05;
 	                	}
 	                }

--- a/scripts/explode_script/explode_script.gml
+++ b/scripts/explode_script/explode_script.gml
@@ -9,7 +9,7 @@ function explode_script(argument0, argument1) {
 	  explode[0]=0;
 	  explode[1]=0;
 	}
-	for (i=0; i<string_count(argument1,argument0); i+=1)
+	for (var i=0; i<string_count(argument1,argument0); i+=1)
 	{
 	  pos=string_pos(argument1,string1);
 	  explode[i]=string_copy(string1,0,pos-1);

--- a/scripts/explode_script/explode_script.gml
+++ b/scripts/explode_script/explode_script.gml
@@ -9,7 +9,7 @@ function explode_script(argument0, argument1) {
 	  explode[0]=0;
 	  explode[1]=0;
 	}
-	for (var i=0; i<string_count(argument1,argument0); i+=1)
+	for (var i=0; i<string_count(argument1,argument0); i++)
 	{
 	  pos=string_pos(argument1,string1);
 	  explode[i]=string_copy(string1,0,pos-1);

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -200,7 +200,7 @@ function collect_role_group(group="standard", location="", opposite=false, searc
 				if (wanted_companies != com) then continue;
 			}
 		}
-	    for (i=0;i<array_length(obj_ini.TTRPG[com]);i++){
+	    for (var i=0;i<array_length(obj_ini.TTRPG[com]);i++){
 	    	add=false;
 			unit=fetch_unit([com,i]);
 			if (unit.name()=="") then continue;
@@ -252,7 +252,7 @@ function stat_valuator(search_params, unit){
 function collect_by_religeon(religion, sub_cult="", location=""){
 	var units = [], unit, count=0, add=false;
 	for (var com=0;com<=10;com++){
-	    for (i=1;i<array_length(obj_ini.TTRPG[com]);i++){
+	    for (var i=1;i<array_length(obj_ini.TTRPG[com]);i++){
 	    	add=false;
 			unit=obj_ini.TTRPG[com][i];
 			if (unit.name()=="")then continue; 	

--- a/scripts/scr_add_corruption/scr_add_corruption.gml
+++ b/scripts/scr_add_corruption/scr_add_corruption.gml
@@ -5,22 +5,21 @@ function scr_add_corruption(is_fleet, modifier_type) {
 
 	// Corrupts marines at the target location
 
-	var i,c,shi,m,co,ide, unit;
-	i=capital_number+escort_number+frigate_number;
-	c=0;shi=0;m=0;co=0;ide=0;
+	var shi,m,co,ide, unit;
+	shi=0;m=0;co=0;ide=0;
 	ships = [];
 	if (is_fleet=true){
 		for (var i=0;i<capital_number;i++){
 			if (obj_ini.ship_carrying[capital_num[i]]>0) then array_push(ships, capital_num[i]);
 		}
-		for (i=0;i<frigate_number;i++){
+		for (var i=0;i<frigate_number;i++){
 			if (obj_ini.ship_carrying[frigate_num[i]]>0) then array_push(ships, frigate_num[i]);
 		}
-		for (i=0;i<escort_number;i++){
+		for (var i=0;i<escort_number;i++){
 			if (obj_ini.ship_carrying[escort_num[i]]>0) then array_push(ships, escort_num[c]);
 		}
-		for (co=0;co<=10;co++){
-			for (i=0;i<array_length(obj_ini.name[co]);i++){
+		for (var co=0;co<=10;co++){
+			for (var i=0;i<array_length(obj_ini.name[co]);i++){
 				if (obj_ini.name[co][i] == "") then continue;
 				unit = fetch_unit([co,i]);
 				if (array_contains(ships, unit.ship_location)){

--- a/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
+++ b/scripts/scr_apothecary_ground/scr_apothecary_ground.gml
@@ -114,37 +114,36 @@ function apothecary_simple(turn_end=true){
 
 	var locations = struct_get_names(unit_spread);
 	with (obj_star){
-		for (i=0;i<array_length(locations);i++){
+		for (var i=0;i<array_length(locations);i++){
 			if (locations[i] == name){
 				array_push(unit_spread[$ locations[i]], self)
 			}
 		}
 	}
 	var cur_units, cur_apoths, cur_techs, total_heal_points, total_tech_points, veh_health, points_spent, cur_system, features;
-	var p, i, a;
 	var total_bionics = scr_item_count("Bionics");
 	var tech_points_used = 0;
-	for (i=0;i<array_length(locations);i++){
+	for (var i=0;i<array_length(locations);i++){
 		cur_system="";
 		if (array_length(unit_spread[$locations[i]]) == 6){
 			cur_system = unit_spread[$locations[i]][5];
 		}		
-		for (p=0;p<5;p++){
+		for (var p=0;p<5;p++){
 			total_heal_points=0;
 			total_tech_points=0;
 			if (array_length(unit_spread[$locations[i]][p]) == 0) then continue;
 			cur_units = unit_spread[$locations[i]][p];
 			cur_apoths = apoth_spread[$locations[i]][p];
 			cur_techs = tech_spread[$locations[i]][p];
-			for (a=0;a<array_length(cur_apoths);a++){
+			for (var a=0;a<array_length(cur_apoths);a++){
 				unit = cur_apoths[a];
 				total_heal_points+=((unit.technology/2)+(unit.wisdom/2)+unit.intelligence)/8;
 			}
-			for (a=0;a<array_length(cur_techs);a++){
+			for (var a=0;a<array_length(cur_techs);a++){
 				unit = cur_techs[a];
 				total_tech_points += unit.forge_point_generation()[0];
 			}
-			for (a=0;a<array_length(cur_units);a++){
+			for (var a=0;a<array_length(cur_units);a++){
 				points_spent = 0;
 				unit = cur_units[a];
 				if (is_array(unit) && total_tech_points>0){

--- a/scripts/scr_array_functions/scr_array_functions.gml
+++ b/scripts/scr_array_functions/scr_array_functions.gml
@@ -48,13 +48,13 @@ function array_find_value(search_array, value){
 }
 
 function array_set_value(choice_array, value){
-	for (i=0;i<array_length(choice_array);i++){
+	for (var i=0;i<array_length(choice_array);i++){
 		choice_array[@ i] = value;
 	}
 }
 
 function array_replace_value(choice_array, value, r_value){
-	for (i=0;i<array_length(choice_array);i++){
+	for (var i=0;i<array_length(choice_array);i++){
 		if (choice_array[i] == value ){
 			choice_array[@ i] = r_value;
 		}

--- a/scripts/scr_cheatcode/scr_cheatcode.gml
+++ b/scripts/scr_cheatcode/scr_cheatcode.gml
@@ -117,7 +117,7 @@ function scr_cheatcode(argument0) {
 					break;
 				case "govmission":
 					with (obj_star) {
-						for (i = 1; i <= planets; i++) {
+						for (var i = 1; i <= planets; i++) {
 							var existing_problem = false; //has_any_problem_planet(i);
 							if (!existing_problem) {
 								if (p_owner[i] == eFACTION.Imperium) {
@@ -130,14 +130,14 @@ function scr_cheatcode(argument0) {
 					break;
 				case "artifactpopulate":
 					with (obj_star) {
-						for (i = 1; i <= planets; i++) {
+						for (var i = 1; i <= planets; i++) {
 							array_push(p_feature[i], new NewPlanetFeature(P_features.Artifact));
 						}
 					}
 					break;
 				case "ruinspopulate":
 					with (obj_star) {
-						for (i = 1; i <= planets; i++) {
+						for (var i = 1; i <= planets; i++) {
 							array_push(p_feature[i], new NewPlanetFeature(P_features.Ancient_Ruins));
 						}
 					}

--- a/scripts/scr_check_equip/scr_check_equip.gml
+++ b/scripts/scr_check_equip/scr_check_equip.gml
@@ -9,10 +9,10 @@ function scr_check_equip(search_item, system, planet_or_ship_id, remove_item) {
 
 
 
-	var man_c=0,man_i=0,c=0,i=0,have=0, unit, marine_present;
+	var man_c=0,man_i=0,have=0, unit, marine_present;
 
-	for (c=0;c<=10;c++){
-	    for (i=1;i<=500;i++){
+	for (var c=0;c<=10;c++){
+	    for (var i=1;i<=500;i++){
     		if (obj_ini.name[c][i]=="") then continue;
     		marine_present=false;
 

--- a/scripts/scr_company_order/scr_company_order.gml
+++ b/scripts/scr_company_order/scr_company_order.gml
@@ -86,7 +86,7 @@ function scr_company_order(company) {
 					create_squad(new_squad_type, company, false);
 				}
 				var sorted_units = 0;
-				for (i=0;i<role_number;i++){
+				for (var i=0;i<role_number;i++){
 					unit = TTRPG[company,squadless[$ role][i]];
 					if (unit.squad != "none"){
 						array_delete(squadless[$ role], i ,1);

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -218,8 +218,7 @@ function scr_company_view(company) {
 }
 
 function other_manage_data(){
-	var v, mans, bad, squads, squad_type, squad_loc, squad_members, unit, unit_loc;
-	v=0;
+	var mans, bad, squads, squad_type, squad_loc, squad_members, unit, unit_loc;
 	mans=0;
 	bad=0;
 	squads=0;

--- a/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
+++ b/scripts/scr_diplomacy_helpers/scr_diplomacy_helpers.gml
@@ -29,7 +29,7 @@ function basic_diplomacy_screen(){
                     draw_set_color(0);
                 
                     var sw=1;
-                    for (i=1;i<5;i++){
+                    for (var i=1;i<5;i++){
                     	if (string_width(string_hash_to_newline(diplo_option[slot]))*sw>530) then sw-=0.05;
                     }
                     if (string_width(string_hash_to_newline(diplo_option[slot]))*sw<=530) and (sw=1) then draw_text_transformed(xx+620,yy+696,string_hash_to_newline(string(diplo_option[slot])),sw,sw,0);

--- a/scripts/scr_draw_unit_stat_data/scr_draw_unit_stat_data.gml
+++ b/scripts/scr_draw_unit_stat_data/scr_draw_unit_stat_data.gml
@@ -110,7 +110,7 @@ function scr_draw_unit_stat_data(manage=false){
 	// draw_set_color(c_black);
 	// draw_rectangle(stat_block.x1,stat_block.y1, stat_block.x1 + (4*array_length(stat_display_list)), stat_block.y1+48+4, 1)
 	var viewing_stat,icon_colour;
-	for (i=0; i<array_length(stat_display_list);i++){
+	for (var i=0; i<array_length(stat_display_list);i++){
 		if (point_in_rectangle(mouse_x, mouse_y, attribute_box.x1,attribute_box.y1,attribute_box.x2,attribute_box.y2)){
 			viewing_stat=true;
 		}else{
@@ -256,7 +256,7 @@ function scr_draw_unit_stat_data(manage=false){
 
 		var x1 = data_block.x2-16;
 		if array_length(traits) != 0 {
-			for (i=0; i<array_length(traits); i++) {
+			for (var i=0; i<array_length(traits); i++) {
 				var trait_name = global.trait_list[$ traits[i]].display_name;
 				var trait_description = string(global.trait_list[$ traits[i]].flavour_text, unit_name);
 				var trait_effect = "";
@@ -277,12 +277,12 @@ function scr_draw_unit_stat_data(manage=false){
 			draw_set_halign(fa_left);
 		}
 
-		for (i=0;i<array_length(stat_tool_tips);i++){
+		for (var i=0;i<array_length(stat_tool_tips);i++){
 			if (point_in_rectangle(mouse_x, mouse_y, stat_tool_tips[i][0], stat_tool_tips[i][1], stat_tool_tips[i][2], stat_tool_tips[i][3])){
 				tooltip_draw(stat_tool_tips[i][4], 300, [stat_tool_tips[i][0], stat_tool_tips[i][3]],,,stat_tool_tips[i][5]);
 			}
 		}
-		for (i=0;i<array_length(trait_tool_tips);i++){
+		for (var i=0;i<array_length(trait_tool_tips);i++){
 			if (point_in_rectangle(mouse_x, mouse_y, trait_tool_tips[i][2], trait_tool_tips[i][1], trait_tool_tips[i][0], trait_tool_tips[i][3])){
 				tooltip_draw(trait_tool_tips[i][4], 300);
 			}

--- a/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
+++ b/scripts/scr_enemy_ai_e/scr_enemy_ai_e.gml
@@ -20,10 +20,10 @@ function scr_enemy_ai_e() {
     var damage = array_create(20,0);
 
 
-    var i = 0;
-    repeat(13) {
-        i += 1;
-        if (present_fleet[i]) then have_fleets += 1;
+    for (var i = 1; i <= 13; i += 1) {
+        if (present_fleet[i]) {
+            have_fleets += 1;
+        }
     }
 
     if (present_fleet[1] > 0) { // Battle1 is reserved for player battles
@@ -743,7 +743,7 @@ function scr_enemy_ai_e() {
         }
     }
 
-    for (i=1;i<=planets;i++){
+    for (var i=1;i<=planets;i++){
         var existing_problem = has_any_problem_planet(i);
         if (!existing_problem){
             if (!irandom(50) && p_owner[i]==eFACTION.Imperium){

--- a/scripts/scr_fleet_functions/scr_fleet_functions.gml
+++ b/scripts/scr_fleet_functions/scr_fleet_functions.gml
@@ -177,10 +177,9 @@ function set_fleet_movement(fastest_route = true){
 function load_unit_to_fleet(fleet, unit){
 	var loaded = false;
 	var all_ships = fleet_full_ship_array(fleet);
-	var i, ship_ident;
 
-	for (i=0;i<array_length(all_ships);i++){
-		ship_ident = all_ships[i];
+	for (var i=0;i<array_length(all_ships);i++){
+		var ship_ident = all_ships[i];
 		  if (obj_ini.ship_capacity[ship_ident]>obj_ini.ship_carrying[ship_ident]){
 		  	obj_ini.ship_carrying[ship_ident]+=unit.size;
 		  	unit.planet_location=0;

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -193,7 +193,7 @@ function navy_attack_player_world(){
 	    if (instance_exists(orbiting)){
 	        var tar=0;
 			var i=0;
-	        for (var i=1;i<=orniting.planets;i++){
+	        for (i=1;i<=orniting.planets;i++){
 	            if (orbiting.p_owner[i]=eFACTION.Player) 
 					and (planet_feature_bool(orbiting.p_feature[i],P_features.Monastery)==0) 
 					and (orbiting.p_guardsmen[i]=0) 
@@ -320,7 +320,7 @@ function scr_navy_unload_guard(planet){
 
 function scr_navy_planet_action(){
 	if (action=="") and (is_orbiting()) and (!guardsmen_unloaded){// Unload if problem sector, otherwise patrol
-	    var p=0,selected_planet=0,highest=0,popu=0,popu_large=false;
+	    var selected_planet=0,highest=0,popu=0,popu_large=false;
     
 	    for (var p=1;p<=orbiting.planets;p++){
 	    	var planet_enemies = planet_imperial_base_enemies(p, orbiting);

--- a/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
+++ b/scripts/scr_imperial_navy_functions/scr_imperial_navy_functions.gml
@@ -193,7 +193,7 @@ function navy_attack_player_world(){
 	    if (instance_exists(orbiting)){
 	        var tar=0;
 			var i=0;
-	        for (i=1;i<=orniting.planets;i++){
+	        for (i = 1; i <= orbiting.planets; i++) {
 	            if (orbiting.p_owner[i]=eFACTION.Player) 
 					and (planet_feature_bool(orbiting.p_feature[i],P_features.Monastery)==0) 
 					and (orbiting.p_guardsmen[i]=0) 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -758,27 +758,24 @@ function scr_initialize_custom() {
 	debugl(ship_summary_str);
 	show_debug_message(ship_summary_str);
 
-	var i = -1;
-	v = 0;
-
 	if (battle_barges>=1){
-	 	for (v=1;v<=battle_barges;v++){
+	 	for (var v=1;v<=battle_barges;v++){
 	 		var new_ship = new_player_ship("Battle Barge", "home")
 		    if (flagship_name!="") and (v=1) then ship[new_ship]=flagship_name;
 		    if (flagship_name="") or (v>1) then ship[new_ship]=global.name_generator.generate_imperial_ship_name();
 		}
 	}
 
-	for(i=0;i<strike_cruisers;i++){
+	for(var i=0;i<strike_cruisers;i++){
 		new_player_ship("Strike Cruiser");
 	}
 
 
-	for(i=0;i<gladius;i++){
+	for(var i=0;i<gladius;i++){
 		new_player_ship("Gladius");
 	}
 
-	for(i=0;i<hunters;i++){
+	for(var i=0;i<hunters;i++){
 		new_player_ship("Hunter");
 	}
 
@@ -847,9 +844,8 @@ function scr_initialize_custom() {
 	var siege = 0,
 		temp1 = 0,
 		intolerant = 0;
-	var k, i, v;
+	var k, v;
 	k = 0;
-	i = 0;
 	v = 0;
 
 	/* Default Specialists */
@@ -1017,17 +1013,15 @@ function scr_initialize_custom() {
 		if (obj_creation.strength <= 2) then seventh = 0;
 		if (obj_creation.strength <= 1) then sixth = 0;
 
-		var bonus_marines = 0,
-			o = 0;
+		var bonus_marines = 0;
 		if (obj_creation.strength > 5) then bonus_marines = (obj_creation.strength - 5) * 50;
 	}
 
 	if (obj_creation.custom != 0) {
-		var bonus_marines = 0,
-			o = 0;
+		var bonus_marines = 0;
 		if (obj_creation.strength > 5) then bonus_marines = (obj_creation.strength - 5) * 50;
 		if scr_has_disadv("Obliterated") then bonus_marines = (obj_creation.strength - 5) * 5;
-		i = 0
+		var i = 0;
 		while (bonus_marines >= 5) {
 			switch (i % 10) {
 				case 0:
@@ -1269,7 +1263,7 @@ function scr_initialize_custom() {
 
 	company = 0;
 	// Initialize default marines for loadouts
-	for (i = 0; i <= 100; i++) {
+	for (var i = 0; i <= 100; i++) {
 		race[100, i] = 1;
 		loc[100, i] = "";
 		name[100, i] = "";
@@ -1285,7 +1279,7 @@ function scr_initialize_custom() {
 	}
 	initialized = 500;
 	// Initialize special marines
-	for (i = 0; i <= 500; i++) {
+	for (var i = 0; i <= 500; i++) {
 		race[0, i] = 1;
 		loc[0, i] = "";
 		name[0, i] = "";
@@ -1301,21 +1295,20 @@ function scr_initialize_custom() {
 		god[0, i] = 0;
 		TTRPG[0, i] = new TTRPG_stats("chapter", 0, i, "blank");
 	}
-	for (i = 0; i <= 100; i++) {
-		i += 1;
-		role[100, i] = "";
-		wep1[100, i] = "";
-		wep2[100, i] = "";
-		armour[100, i] = "";
-		gear[100, i] = "";
-		mobi[100, i] = ""; //hirelings??
-		role[102, i] = "";
-		wep1[102, i] = "";
-		wep2[102, i] = "";
-		armour[102, i] = "";
-		gear[102, i] = "";
-		mobi[102, i] = ""; //hirelings??
-	}
+    for (var i = 0; i <= 100; i++) {
+        role[100, i] = "";
+        wep1[100, i] = "";
+        wep2[100, i] = "";
+        armour[100, i] = "";
+        gear[100, i] = "";
+        mobi[100, i] = ""; //hirelings??
+        role[102, i] = "";
+        wep1[102, i] = "";
+        wep2[102, i] = "";
+        armour[102, i] = "";
+        gear[102, i] = "";
+        mobi[102, i] = ""; //hirelings??
+    }
 
 	defaults_slot = 100;
 
@@ -2970,8 +2963,7 @@ function scr_initialize_custom() {
 	}
 
 	// Honour Guard
-	var _honour_guard_count = 0,
-		chapter_option, o, unit;
+	var _honour_guard_count = 0, unit;
 	o = 0;
 	chapter_option = 0;
 	repeat(4) {
@@ -2983,7 +2975,7 @@ function scr_initialize_custom() {
 	if (_honour_guard_count == 0) {
 		_honour_guard_count = 3
 	}
-	for (i = 0; i < min(_honour_guard_count, 10); i++) {
+	for (var i = 0; i < min(_honour_guard_count, 10); i++) {
 		k += 1;
 		commands += 1;
 		man_size += 1;
@@ -3012,7 +3004,7 @@ function scr_initialize_custom() {
 
 	// First Company
 	company = 1;
-	for (i = 0; i < 501; i++) {
+	for (var i = 0; i < 501; i++) {
 		race[company, i] = 1;
 		loc[company, i] = "";
 		name[company, i] = "";
@@ -3287,7 +3279,7 @@ function scr_initialize_custom() {
 		spawn_unit.roll_experience();
 	}
 
-	for (i = 0; i < 4; i++) {
+	for (var i = 0; i < 4; i++) {
 		v += 1;
 		man_size += 10;
 		veh_race[company, v] = 1;
@@ -3390,7 +3382,7 @@ function scr_initialize_custom() {
 	//non HQ and non firsst company initialised here
 	for (company = 2; company < 11; company++) {
 		// Initialize marines
-		for (i = 0; i < 501; i++) {
+		for (var i = 0; i < 501; i++) {
 			race[company, i] = 1;
 			loc[company, i] = "";
 			name[company, i] = "";
@@ -3417,7 +3409,6 @@ function scr_initialize_custom() {
 			stahp = 0;
 
 		v = 0;
-		i = -1;
 		k = 0;
 		v = 0;
 
@@ -4200,13 +4191,11 @@ function scr_initialize_custom() {
 	}
 
 
-	var i;
-	i = -1;
-	repeat(121) {
-		i += 1;
-		slave_batch_num[i] = 0;
-		slave_batch_eta[i] = 0;
-	}
+    for (var i = 0; i < 121; i += 1) {
+        slave_batch_num[i] = 0;
+        slave_batch_eta[i] = 0;
+    }
+
 
 
 

--- a/scripts/scr_item_count/scr_item_count.gml
+++ b/scripts/scr_item_count/scr_item_count.gml
@@ -2,8 +2,8 @@ function scr_item_count(item_type, quality="any") {
 
 	// This script checks the equipment variables for the named item and returns the combined quantity
 
-	var i=0,von=0;
-	for (i=0;i<array_length(obj_ini.equipment);i++){
+	var von=0;
+	for (var i=0;i<array_length(obj_ini.equipment);i++){
 	   if (obj_ini.equipment[i]==item_type){
 	   		/*in theory we should be able to break here but there seems
 	   		to be the implication that an equipment item can be in the 

--- a/scripts/scr_load/scr_load.gml
+++ b/scripts/scr_load/scr_load.gml
@@ -21,7 +21,7 @@ function load_marine_struct(company, marine){
 
 function scr_load(save_part, save_id) {
 	var unit;
-	var rang=0,i=0,g=0,stars=0,pfleets=0,efleets=0;
+	var rang=0,stars=0,pfleets=0,efleets=0;
 
 
 
@@ -259,7 +259,7 @@ function scr_load(save_part, save_id) {
 
 
 	    if (global.restart=0){
-	        var g;g=-1;repeat(200){g+=1;
+	        var g = -1;repeat(200){g+=1;
 	            obj_ini.ship[g]=ini_read_string("Ships","shi"+string(g),"");
 	            obj_ini.ship_uid[g]=ini_read_real("Ships","shi_uid"+string(g),0);
 	            obj_ini.ship_class[g]=ini_read_string("Ships","shi_class"+string(g),"");
@@ -319,7 +319,6 @@ function scr_load(save_part, save_id) {
 	    good=0;coh=100;mah=-1;
 
 	    if (global.restart=0){
-	        var coh,mah,good;
 	        good=0;coh=10;mah=205;
 	        repeat(2255){
 	            if (good=0){
@@ -351,7 +350,6 @@ function scr_load(save_part, save_id) {
 	            }
 	        }
 
-	        var coh,mah,good;
 	        good=0;coh=100;mah=-1;
 	        repeat(31){mah+=1;
 	            obj_ini.race[coh,mah]=ini_read_real("Mar","co"+string(coh)+"."+string(mah),0);

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2205,7 +2205,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 
 	    }*/
     	if (homestar!="none"){
-	        for (i=1;i<=homestar.planets;i++){
+	        for (var i=1;i<=homestar.planets;i++){
 	        	if (homestar.p_owner[i]==eFACTION.Player||
 	        		(obj_controller.faction_status[eFACTION.Imperium]!="War" && 
 	        		array_contains(obj_controller.imperial_factions, homestar.p_owner[i]))){

--- a/scripts/scr_mission_reward/scr_mission_reward.gml
+++ b/scripts/scr_mission_reward/scr_mission_reward.gml
@@ -192,7 +192,7 @@ function scr_mission_reward(argument0, argument1, argument2) {
 	        scr_popup("Mechanicus Mission Completed","The Adeptus Mechanicus have finished experimenting on your marines.  All of your astartes have survived, though they refuse to speak of the experience.  200 Requisition has been provided by the Mechanicus as a reward.","mechanicus","");
 	        obj_controller.disposition[3]+=1;
 	        obj_controller.requisition+=200;
-	        var found=0,com=-1,i=0,unit;
+	        var found=0,i=0,unit;
 	        for (var com=0;com<=10;com++){
 	            if (found<10){
 	                for (i=0;i<=array_length(obj_ini.TTRPG[com]);i++){

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -253,7 +253,7 @@ function scr_player_combat_weapon_stacks() {
             var j=0,good=0,open=0, weapon, vehicle_weapon_set;
             if (veh_dead[g]!=1){
                 vehicle_weapon_set = [veh_wep1[g],veh_wep2[g],veh_wep3[g]]
-                for (wep_slot=0;wep_slot<3;wep_slot++){
+                for (var wep_slot=0;wep_slot<3;wep_slot++){
                     var weapon_check = vehicle_weapon_set[wep_slot];
                     if (weapon_check!=""){
                         weapon=gear_weapon_data("weapon",weapon_check,"all", false, "standard");
@@ -284,7 +284,7 @@ function scr_player_combat_weapon_stacks() {
 
 
     if (men==1) and (veh==0)and (obj_ncombat.player_forces=1) {
-        var i=0,h=0;
+        var h=0;
         for (var i=0;i<array_length(unit_struct);i++) {
             if (h=0) {
                 unit = unit_struct[i];

--- a/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
+++ b/scripts/scr_player_fleet_functions/scr_player_fleet_functions.gml
@@ -32,7 +32,7 @@ function split_selected_into_new_fleet(start_fleet="none"){
         // Pass over ships to the new fleet, if they are selected
         var cap_number = array_length(capital);
 
-        for (i=0; i<cap_number;i++){
+        for (var i=0; i<cap_number;i++){
             if (capital[i]!="") and (capital_sel[i]){
             	move_ship_between_player_fleets(self, new_fleet,"capital", i);
             	i--;
@@ -40,7 +40,7 @@ function split_selected_into_new_fleet(start_fleet="none"){
             }
         }
         var frig_number = array_length(frigate);
-        for (i=0; i<frig_number;i++){
+        for (var i=0; i<frig_number;i++){
             if (frigate[i]!="") and (frigate_sel[i]){
             	move_ship_between_player_fleets(self, new_fleet,"frigate", i);
             	i--;
@@ -48,7 +48,7 @@ function split_selected_into_new_fleet(start_fleet="none"){
             }
         }
         var esc_number = array_length(escort);
-        for (i=0; i<esc_number;i++){
+        for (var i=0; i<esc_number;i++){
             if (escort[i]!="") and (escort_sel[i]){
             	move_ship_between_player_fleets(self, new_fleet,"escort", i)
             	i--;
@@ -233,19 +233,19 @@ function player_fleet_ship_count(fleet="none"){
 		frigate_number = 0;
 		escort_number = 0;
 
-		for (i=0; i<array_length(capital);i++){
+		for (var i=0; i<array_length(capital);i++){
 			if (capital[i]!=""){
 				ship_count++;
 				capital_number++;
 			}
 		}
-		for (i=0; i<array_length(frigate);i++){
+		for (var i=0; i<array_length(frigate);i++){
 			if (frigate[i]!=""){
 				ship_count++;
 				frigate_number++;
 			}
 		}
-		for (i=0; i<array_length(escort);i++){
+		for (var i=0; i<array_length(escort);i++){
 			if (escort[i]!=""){
 				ship_count++;
 				escort_number++;
@@ -262,13 +262,13 @@ function player_fleet_ship_count(fleet="none"){
 function player_fleet_selected_count(fleet="none"){
 	var ship_count = 0;
 	if (fleet=="none"){
-		for (i=0; i<array_length(capital);i++){
+		for (var i=0; i<array_length(capital);i++){
 			if(capital[i]!="" && capital_sel[i]) then ship_count++;
 		}
-		for (i=0; i<array_length(frigate);i++){
+		for (var i=0; i<array_length(frigate);i++){
 			if(frigate[i]!="" && frigate_sel[i]) then ship_count++;
 		}
-		for (i=0; i<array_length(escort);i++){
+		for (var i=0; i<array_length(escort);i++){
 			if(escort[i]!="" && escort_sel[i]) then ship_count++;
 		}
 	} else {

--- a/scripts/scr_population_influence/scr_population_influence.gml
+++ b/scripts/scr_population_influence/scr_population_influence.gml
@@ -9,7 +9,7 @@ function adjust_influence(faction, value, planet, star="none"){
 			var difference = total_influence-100;
 			while (difference>0 && loop<100){
 				loop++;
-				for (i=0;i<15;i++){
+				for (var i=0;i<15;i++){
 					if (p_influence[planet][i]>0){
 						p_influence[planet][i]--;
 						difference--;
@@ -19,7 +19,7 @@ function adjust_influence(faction, value, planet, star="none"){
 		} else if (total_influence<0){
 			while (total_influence<0 && loop<100){
 				loop++;
-				for (i=0;i<15;i++){
+				for (var i=0;i<15;i++){
 					if (p_influence[planet][i]<0){
 						p_influence[planet][i]++;
 						total_influence++;
@@ -35,7 +35,7 @@ function adjust_influence(faction, value, planet, star="none"){
 }
 
 function merge_influences(doner_influence, planet){
-	for (i=0;i<15;i++){
+	for (var i=0;i<15;i++){
 		if (i==2 )then continue;
 		adjust_influence(i,(p_influence[planet][i]+doner_influence[i]/2),planet);
 	}

--- a/scripts/scr_quest/scr_quest.gml
+++ b/scripts/scr_quest/scr_quest.gml
@@ -28,15 +28,14 @@ function scr_quest(quest_satus=0, quest_name, quest_fac, quest_end) {
 
 
 	else if (quest_satus>0){// 1 = Fail, 2 = Accomplish, 3 = Clear
-	    var que,i;
-	    que=0;i=0;
+	    var que = 0;
     
-	    repeat(10){
-	    	if (que=0){
-	    		i+=1;
-	    		if (obj_controller.quest[i]=quest_name) then que=i;
-	    	}
-	    }
+        for (var i = 1; i <= 10; i += 1) {
+            if (que == 0 && obj_controller.quest[i] == quest_name) {
+                que = i;
+                break;
+            }
+        }
     
 	    if (quest_name="fund_elder") and (quest_satus=1){
 	        // obj_controller.disposition[6]-=2;// Player going 'maybe' and then waiting out the quest duration

--- a/scripts/scr_recent/scr_recent.gml
+++ b/scripts/scr_recent/scr_recent.gml
@@ -17,7 +17,6 @@ function scr_recent(recent_type="", keyword="", numerical_data=0) {
 
 	// Squish the array when asked to
 	if (string(recent_type)="") and (string(keyword)="") and (real(numerical_data)=0){
-	    var i=0;
 	    obj_controller.recent_happenings-=1;
 	    delete_positions = [];    
 	    for (var i=0;i<array_length(obj_controller.recent_type);i++){
@@ -26,7 +25,7 @@ function scr_recent(recent_type="", keyword="", numerical_data=0) {
 	        }
 	    }
 	    var del_pos;
-	    for (i=0;i<array_length(delete_positions);i++){
+	    for (var i=0;i<array_length(delete_positions);i++){
 	    	del_pos = delete_positions[i]
 	    	array_delete(obj_controller.recent_type, del_pos, 1);
 	    	array_delete(obj_controller.recent_keyword, del_pos, 1);

--- a/scripts/scr_role_count/scr_role_count.gml
+++ b/scripts/scr_role_count/scr_role_count.gml
@@ -2,10 +2,9 @@ function scr_role_count(target_role, search_location="", return_type="count") {
 
 	// Take a guess
 
-	var com, i, count, coom, units=[], unit,match;
+	var com, count, coom, units=[], unit,match;
 
 	count=0;
-	i=0;
 	com=0;
 	coom=-999;
 
@@ -29,7 +28,7 @@ function scr_role_count(target_role, search_location="", return_type="count") {
 
 	if (coom>=0){
 	    com=coom;
-	    for (i=0;i<array_length(obj_ini.TTRPG[com]);i++){
+	    for (var i=0;i<array_length(obj_ini.TTRPG[com]);i++){
 			unit=obj_ini.TTRPG[com][i];
 			if (unit.name()=="")then continue; 	
 	        if (unit.role()==target_role) && (obj_ini.god[com][i]<10){
@@ -44,8 +43,7 @@ function scr_role_count(target_role, search_location="", return_type="count") {
 
 
 	if (coom<0) then repeat(11){
-	    i=0;
-	    for (i=0;i<array_length(obj_ini.TTRPG[com]);i++){
+	    for (var i=0;i<array_length(obj_ini.TTRPG[com]);i++){
 			match=false;
 			unit=obj_ini.TTRPG[com][i];
 			if (unit.name()=="")then continue;

--- a/scripts/scr_save/scr_save.gml
+++ b/scripts/scr_save/scr_save.gml
@@ -28,7 +28,7 @@ function scr_save(save_part,save_id) {
 
 	    var num=instance_number(obj_star);
 	    instance_array=0;
-	    for (i=0; i<num; i+=1){
+	    for (var i=0; i<num; i+=1){
 	        instance_array[i] = instance_find(obj_star,i);
 	        // save crap here
 	        ini_write_string("Star","sr"+string(i)+"name",instance_array[i].name);
@@ -139,7 +139,7 @@ function scr_save(save_part,save_id) {
 	    // Temporary artifact objects
 	    ini_write_real("Controller","temp_arti",instance_number(obj_temp_arti));
 	    num=instance_number(obj_temp_arti);instance_array=0;
-	    for (i=0; i<num; i+=1){
+	    for (var i=0; i<num; i+=1){
 	        instance_array[i] = instance_find(obj_temp_arti,i);
 	        ini_write_real("Star","ar"+string(i)+"x",instance_array[i].x);
 	        ini_write_real("Star","ar"+string(i)+"y",instance_array[i].y);
@@ -149,7 +149,7 @@ function scr_save(save_part,save_id) {
 	    num=0;tot=0;num=instance_number(obj_p_fleet);
 	    instance_array[tot]=0;
 
-	    for (i=0; i<num; i+=1){
+	    for (var i=0; i<num; i+=1){
 	        instance_array[i] = instance_find(obj_p_fleet,i);
 
 	        ini_write_real("Fleet","pf"+string(i)+"image",instance_array[i].image_index);
@@ -199,7 +199,7 @@ function scr_save(save_part,save_id) {
 	    num=0;tot=0;num=instance_number(obj_en_fleet);
 	    instance_array[tot]=0;
 
-	    for (i=0; i<num; i+=1){
+	    for (var i=0; i<num; i+=1){
 	        instance_array[i] = instance_find(obj_en_fleet,i);
 	        ini_write_real("Fleet",$"ef{i}owner",instance_array[i].owner);
 	        ini_write_real("Fleet",$"ef{i}x",instance_array[i].x);
@@ -338,7 +338,7 @@ function scr_save(save_part,save_id) {
 		ini_encode_and_json("Ini",$"equipment_condition",obj_ini.equipment_condition);
 		ini_encode_and_json("Ini",$"equipment_quality",obj_ini.equipment_quality);
 
-	    for (g=0;g<array_length(obj_ini.artifact);g++){
+	    for (var g=0;g<array_length(obj_ini.artifact);g++){
             ini_write_string("Ini","artifact"+string(g),obj_ini.artifact[g]);
             ini_write_string("Ini","artifact_tags"+string(g),base64_encode(json_stringify(obj_ini.artifact_tags[g])));
             ini_write_real("Ini","artifact_ident"+string(g),obj_ini.artifact_identified[g]);

--- a/scripts/scr_special_view/scr_special_view.gml
+++ b/scripts/scr_special_view/scr_special_view.gml
@@ -1,8 +1,7 @@
 function scr_special_view(command_group) {
 
 	// Works as COMPANY VIEW but for the subsections of HQ
-
-	var v, i; 
+ 
 	var mans=0, onceh, company=0, bad=0, oth=0, unit;
 	gogogo=0;
 	vehicles=0;
@@ -11,11 +10,11 @@ function scr_special_view(command_group) {
 
 	var squads=0, squad_typ="", squad_loc=0, squad_members=0;
 
-	for (i=0;i<20;i++){
+	for (var i=0;i<20;i++){
 		sel_uni[i]="";
 		sel_veh[i]="";
 	}
-	for (i=0;i<501;i++){
+	for (var i=0;i<501;i++){
 
 	    if (i<=50){
 	    	penit_co[i]=0;
@@ -27,8 +26,6 @@ function scr_special_view(command_group) {
 
 	mans=0;
 	vehicles=0;
-	v=0;
-	i=0;
 	b=0;
 
 	// v: check number
@@ -36,7 +33,7 @@ function scr_special_view(command_group) {
 
 	b=0;
 	if (command_group==11) or (command_group==0){				//HQ units
-		for (v = 0;v<array_length(obj_ini.TTRPG[0]);v++){
+		for (var v = 0;v<array_length(obj_ini.TTRPG[0]);v++){
 			bad=0;
 			if (obj_ini.name[0][v]== ""){continue;}
 			if (obj_ini.TTRPG[0][v].ship_location>0){
@@ -98,10 +95,9 @@ function scr_special_view(command_group) {
 
 	// b=last_man;
 	last_man=b;
-	i=0;
 	last_vehicle=0;
 
-	for (i=1;i<101;i++){// 100
+	for (var i=1;i<101;i++){// 100
 	    if (obj_ini.veh_race[company,i]!=0){
 	    	add_vehicle_to_manage_arrays([company,i]);
 	    }
@@ -109,10 +105,9 @@ function scr_special_view(command_group) {
 
 
 
-	i=0;
 	squads=0;
 	//TODO unify this data with other_manage_data() method
-	for (i=1;i<array_length(display_unit);i++){
+	for (var i=1;i<array_length(display_unit);i++){
 		onceh=0;
 	    var ahuh=0;
 	    if (man[i]="man"){if (ma_role[i]!="") then ahuh=1;}

--- a/scripts/scr_squads/scr_squads.gml
+++ b/scripts/scr_squads/scr_squads.gml
@@ -25,7 +25,7 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 	for (var s = 0; s < 2;s++){
 		if (struct_exists(squad_fulfilment ,sgt_types[s])){
 			sergeant_found = false;
-			for (i = 0; i < array_length(obj_ini.TTRPG[company]);i++){
+			for (var i = 0; i < array_length(obj_ini.TTRPG[company]);i++){
 				if(!is_struct(obj_ini.TTRPG[company][i])){
 					obj_ini.TTRPG[company][i]= new TTRPG_stats("chapter", company,i,"blank");
 				}
@@ -42,7 +42,7 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 			}
 		}
 	}
-	for (i = 0; i < array_length( obj_ini.TTRPG[company]);i++){							//fill squad roles
+	for (var i = 0; i < array_length( obj_ini.TTRPG[company]);i++){							//fill squad roles
 		if(!is_struct(fetch_unit([company,i]))){ //checkposition is valid marine struct
 			obj_ini.TTRPG[company][i]= new TTRPG_stats("chapter", company,i,"blank");
 		}
@@ -69,7 +69,7 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 		if (struct_exists(squad_fulfilment ,sgt_types[s])) and (!sergeant_found){
 			var highest_exp = 0;
 			var exp_unit;
-			for (i = 0; i < array_length(squad.members);i++){
+			for (var i = 0; i < array_length(squad.members);i++){
 				if (i==0){
 					exp_unit = fetch_unit(squad.members[0]);
 					highest_exp = exp_unit.experience;
@@ -86,7 +86,7 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 	}
 	//evaluate if the minimum unit type requirements have been met to create a new squad
 	fulfilled = true;
-	for (i = 0;i < array_length(squad_unit_types);i++){
+	for (var i = 0;i < array_length(squad_unit_types);i++){
 		if (squad_fulfilment[$ squad_unit_types[i]] < fill_squad[$ squad_unit_types[i]][$ "min"]){
 			fulfilled = false;
 			break
@@ -103,7 +103,7 @@ function create_squad(squad_type, company, squad_loadout = true, squad_index=fal
 		}			
 		//update units squad marker
 		squad.squad_fulfilment = squad_fulfilment;
-		for (i = 0; i < array_length(squad.members);i++){
+		for (var i = 0; i < array_length(squad.members);i++){
 			unit = fetch_unit(squad.members[i]);
 			if (!squad_index){
 				unit.squad = squad_count;
@@ -155,7 +155,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 		var required_load, unit_type, load_out_name, load_out_areas, load_out_slot,load_item, optional_load, item_to_add;
 		squad_unit_types = find_squad_unit_types();
 		var full_squad_data =  obj_ini.squad_types[$ type];
-		for (i = 0;i < array_length(squad_unit_types);i++){
+		for (var i = 0;i < array_length(squad_unit_types);i++){
 			unit_type = squad_unit_types[i];
 			required_load = "none";
 			optional_load = "none";
@@ -322,7 +322,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 		var unit;
 		var highest_exp = 0;
 		var member_length = array_length(members);
-		for (i = 0; i < member_length;i++){
+		for (var i = 0; i < member_length;i++){
 			unit = fetch_unit(members[i]);
 			if (unit.name() == ""){
 				array_delete(members, i, 1);
@@ -399,7 +399,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 		required = {};
 		space = {};
 		has_space = false;
-		for (i = 0;i < array_length(squad_unit_types);i++){
+		for (var i = 0;i < array_length(squad_unit_types);i++){
 			if (squad_fulfilment[$ squad_unit_types[i]] < fill_squad[$ squad_unit_types[i]][$ "max"]){
 				space[$ squad_unit_types[i]] = fill_squad[$ squad_unit_types[i]][$ "max"] - squad_fulfilment[$ squad_unit_types[i]];
 			}
@@ -452,7 +452,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 		var in_orbit=false;
 		var planet_side=false;
 		var exact_loc = false;
-		for (i = 0; i < member_length;i++){
+		for (var i = 0; i < member_length;i++){
 			unit = fetch_unit(members[i]);
 			if (unit.name() == ""){
 				array_delete(members, i, 1);
@@ -621,7 +621,7 @@ function UnitSquad(squad_type = undefined, company = undefined) constructor{
 function game_start_squads(){
 	obj_ini.squads = [];
 	var last_squad_count
-	for (company=2;company < 10;company++){
+	for (var company=2;company < 10;company++){
 		create_squad("command_squad", company);
 		last_squad_count = array_length(obj_ini.squads);
 		while (last_squad_count == array_length(obj_ini.squads)){ ///keep making tact squads for as long as there are enough tact marines
@@ -690,7 +690,7 @@ function game_start_squads(){
 	}
 
 	with (obj_ini){
-		for (i=0;i<11;i++){
+		for (var i=0;i<11;i++){
 			scr_company_order(i)
 		}
 	}

--- a/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
+++ b/scripts/scr_system_search_helpers/scr_system_search_helpers.gml
@@ -211,7 +211,7 @@ function find_population_doners(doner_to=0){
     var pop_doner_options = [];
 	with(obj_star){
 		if (obj_star.id == doner_to) then continue;
-	   for (r=1;r<=planets;r++){
+	   for (var r=1;r<=planets;r++){
 	        if ((p_owner[r]=eFACTION.Imperium) and (p_type[r]=="Hive") and (p_population[r]>0) and (p_large[r])){
                 array_push(pop_doner_options, [id, r]);
             };
@@ -252,7 +252,7 @@ function nearest_from_array(xx,yy,list){
 function is_dead_star(star="none"){
 	var dead_star=true;
 	if (star=="none"){
-		for (i=1;i<=planets;i++){
+		for (var i=1;i<=planets;i++){
 			if (p_type[i] !="dead"){
 				dead_star=false;
 				break;

--- a/scripts/scr_trade/scr_trade.gml
+++ b/scripts/scr_trade/scr_trade.gml
@@ -16,8 +16,7 @@ function scr_trade(argument0) {
 
 
 
-	var i=0;
-	repeat(4){i+=1;
+    for (var i = 1; i < 5; i++) {
 	    if (trade_give[i]="Requisition") and (trade_mnum[i]>0) then my_worth+=trade_mnum[i];
     
 	    if (trade_give[i]="Gene-Seed") and (trade_mnum[i]>0){
@@ -188,13 +187,13 @@ function scr_trade(argument0) {
     
 	    // show_message("A: "+string(liscensing));
     
-	    i=0;var goods;goods="";
+	    ;var goods;goods="";
 	   
     
     
 	    // Temporary work around
-	    if (lisc>0){var i;i=0;
-	        repeat(4){i+=1;
+	    if (lisc>0){
+            for (var i = 1; i <= 4; i += 1) {
 	            if (trade_give[i]="Requisition") then requisition-=trade_mnum[i];
 	            if (trade_give[i]="Gene-Seed") and (trade_mnum[i]>0){
 	                gene_seed-=trade_mnum[i];
@@ -204,14 +203,21 @@ function scr_trade(argument0) {
 	            }
 	            if (trade_give[i]="Info Chip") and (trade_mnum[i]>0) then info_chips-=trade_mnum[i];
 	            if (trade_give[i]="STC Fragment") and (trade_mnum[i]>0){
-	                var remov,p;remov=0;p=0;
-	                repeat(100){
-	                    if (remov=0){p=choose(1,2,3);
-	                        if (p=1) and (stc_wargear_un>0){stc_wargear_un-=1;remov=1;}
-	                        if (p=2) and (stc_vehicles_un>0){stc_vehicles_un-=1;remov=1;}
-	                        if (p=3) and (stc_ships_un>0){stc_ships_un-=1;remov=1;}
-	                    }
-	                }
+                    for (var j = 0; j < 100; j += 1) {
+                        var p = choose(1, 2, 3);
+                        if (p == 1 && stc_wargear_un > 0) {
+                            stc_wargear_un -= 1;
+                            break;
+                        }
+                        if (p == 2 && stc_vehicles_un > 0) {
+                            stc_vehicles_un -= 1;
+                            break;
+                        }
+                        if (p == 3 && stc_ships_un > 0) {
+                            stc_ships_un -= 1;
+                            break;
+                        }
+                    }
 	            }
 	        }
         
@@ -272,7 +278,7 @@ function scr_trade(argument0) {
 	        // show_message("TG2:"+string(instance_number(obj_temp2))+", TG3:"+string(instance_number(obj_temp3))+", TG4:"+string(instance_number(obj_ground_mission)));
         
         
-	        var targ, flit, i,chasing;chasing=0;targ=0;// Set target, chase
+	        var targ, flit, chasing;chasing=0;targ=0;// Set target, chase
         
 	        // if (obj_ini.fleet_type != ePlayerBase.home_world){
 	            if (instance_exists(obj_temp2)) then targ=instance_nearest(obj_temp2.x,obj_temp2.y,obj_temp3);

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -53,7 +53,7 @@ function scr_ui_manage() {
 	        selecting_planet=0;
 	        man_size=0;
 		}	
-		var unit,i,x1,x2,y1,y2, var_text;
+		var unit,x1,x2,y1,y2, var_text;
 		var romanNumerals=scr_roman_numerals();	
 		var tooltip_text="",bionic_tooltip="",tooltip_drawing=[];
 			var invalid_locations = ["Mechanicus Vessel", "Terra"];
@@ -1119,7 +1119,7 @@ function scr_ui_manage() {
 			}
 		}
 	    var tip, coords;
-		for (i=0;i < array_length(tooltip_drawing); i++){
+		for (var i=0;i < array_length(tooltip_drawing); i++){
 			tip = tooltip_drawing[i];
 			coords=tip[1];
 			if (point_in_rectangle(mouse_x, mouse_y, coords[0],coords[1],coords[2],coords[3])){

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -48,7 +48,7 @@ function UnitQuickFindPanel() constructor{
 		for (var i = 0;i<=200; i++){
 			obj_ini.ship_carrying[i]=0
 		};
-		var u, unit, unit_location, group;
+		var unit, unit_location, group;
 	    garrison_log = {};
 	    for (var co=0;co<11;co++){
 	    	for (var u=0;u<array_length(obj_ini.TTRPG[co]);u++){
@@ -839,7 +839,7 @@ function planet_selection_action(){
 					        
 					        // STC Grab
 					        if (planet_feature_bool(target.p_feature[sel_plan], P_features.STC_Fragment) == 1) and (recon=0){
-					            var frag,tch,mch;frag=0;tch=0;mch=0;
+					            var tch,mch;frag=0;tch=0;mch=0;
 					            for (var frag=0;frag<array_length(obj_controller.display_unit);frag++){
 					                if (obj_controller.man[frag]!="") and (obj_controller.man_sel[frag]==1){
 					                    if (obj_controller.ma_role[frag]=obj_ini.role[100][16]) or ((obj_controller.ma_role[frag]="Forge Master")){

--- a/scripts/scr_weapon/scr_weapon.gml
+++ b/scripts/scr_weapon/scr_weapon.gml
@@ -2676,7 +2676,7 @@ function gear_weapon_data(search_area="any",item,wanted_data="all", sub_class=fa
     gear_areas =  ["gear","armour","mobility"];
     if (search_area=="any"){
         data_found=false;
-        for (i=0;i<3;i++){
+        for (var i=0;i<3;i++){
            if (struct_exists(global.gear[$ gear_areas[i]],item)){
                 equip_area=global.gear;
                 item_data_set=global.gear[$ gear_areas[i]][$item];


### PR DESCRIPTION
Ensure all loop variables are declared with `var` inside `for` loops to fix scoping issues and prevent implied globals.