### PR TITLE
feat: warp route screen pan on key combo; fix its tooltip

### DIFF
--- a/objects/obj_fleet_select/Draw_0.gml
+++ b/objects/obj_fleet_select/Draw_0.gml
@@ -54,6 +54,9 @@ if (player_fleet.just_left){
         }
     }
 }
+if (!currently_entered){
+    currently_entered =  keyboard_check(vk_shift);
+}
 
 if (owner  == eFACTION.Player) and (player_fleet.action==""){
     var xx = __view_get( e__VW.XView, 0 );
@@ -155,8 +158,8 @@ if (owner  == eFACTION.Player) and (player_fleet.action==""){
     }
 }
 
-if (mouse_check_button_pressed(mb_left)){
-    if (!currently_entered && point_distance(mouse_x,mouse_y,player_fleet.x,player_fleet.y)>32){
+if (mouse_check_button_pressed(mb_left) ){
+    if (!currently_entered && point_distance(mouse_x,mouse_y,player_fleet.x,player_fleet.y)>32 && !keyboard_check(vk_shift)){
         instance_destroy();
     }
 }

--- a/objects/obj_p_fleet/Draw_0.gml
+++ b/objects/obj_p_fleet/Draw_0.gml
@@ -26,26 +26,28 @@ if (obj_controller.zoomed=1){
         within=1;      
     } 
 }
+
 var select_instance = instance_exists(obj_fleet_select);
 if (!select_instance) then selected=0;
-if (within){
-    if (mouse_check_button_pressed(mb_left) && obj_controller.menu==0 && !selected){
-        alarm[3]=1;
-    }  
-} else (mouse_check_button_pressed(mb_left)){
-    if (selected){
-        if (select_instance){
-            if (instance_exists(obj_fleet_select.player_fleet)){
-                if !(obj_fleet_select.player_fleet.id == self.id && !obj_fleet_select.currently_entered){
-                    selected=0;
+if ( !keyboard_check(vk_shift)){
+    if (within){
+        if (mouse_check_button_pressed(mb_left) && obj_controller.menu==0 && !selected){
+            alarm[3]=1;
+        }  
+    } else (mouse_check_button_pressed(mb_left)){
+        if (selected){
+            if (select_instance){
+                if (instance_exists(obj_fleet_select.player_fleet)){
+                    if !(obj_fleet_select.player_fleet.id == self.id && !obj_fleet_select.currently_entered){
+                        selected=0;
+                    }
                 }
             }
+        } else {
+            selected=0;
         }
-    } else {
-        selected=0;
     }
 }
-
 // if (obj_controller.selected!=0) and (selected=1) then within=1;
 
 if (obj_controller.selecting_planet>0){

--- a/objects/obj_planet_map/Create_0.gml
+++ b/objects/obj_planet_map/Create_0.gml
@@ -1,7 +1,7 @@
 /// @description Insert description here
 // You can write your code in this editor
 depth=1;
-warp_point_hover = false;
-hover_time = 0;
-hover_loc = [];
+// warp_point_hover = false;
+// hover_time = 0;
+// hover_loc = [];
 

--- a/objects/obj_star_select/Mouse_50.gml
+++ b/objects/obj_star_select/Mouse_50.gml
@@ -27,7 +27,7 @@ if (debug!=0) then exit;
 
     //TODO centralise this logic
     if (instance_exists(obj_fleet_select)){
-         if (obj_fleet_select.currently_entered) then exit;
+         if (obj_fleet_select.currently_entered)  then exit;
     }
 
 

--- a/objects/obj_tooltip/Draw_75.gml
+++ b/objects/obj_tooltip/Draw_75.gml
@@ -67,12 +67,12 @@ for (var i=0;i<array_length(queue);i++){
 	var _rect_y = _coords[1];
 
 	// Check if the tooltip goes over the right part of the screen and flip left if so
-	if (_rect_x + _rect_w > __view_get(e__VW.WView, 0) - _screen_hpadding) {
+	if (_rect_x + _rect_w > display_get_gui_width() - _screen_hpadding) {
 		_rect_x = _coords[0] - _rect_w - _screen_hpadding;
 	}
 
 	// Check if the tooltip goes over the bottom part of the screen and flip up if so
-	if (_rect_y + _rect_h > __view_get(e__VW.HView, 0) - _screen_vpadding) {
+	if (_rect_y + _rect_h > display_get_gui_height() - _screen_vpadding) {
 		_rect_y = max(_screen_vpadding, _coords[1] - _rect_h - _screen_vpadding);
 	}
 

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -137,8 +137,12 @@ function draw_warp_lanes(){
 			var hit_box = [route_coords[0]+dist_x-(warp_width/2),route_coords[1]+dist_y-(warp_height/2), route_coords[0]+dist_x+(warp_width/2) ,route_coords[1]+dist_y+(warp_height/2) ];
 			
 			var allow_tooltips = (!instance_exists(obj_star_select))
+
 			if (allow_tooltips && instance_exists(obj_fleet_select)){
-				allow_tooltips = !obj_fleet_select.currently_entered;
+
+				var mouse_consts = return_mouse_consts();
+
+				allow_tooltips = !obj_fleet_select.currently_entered || (mouse_consts[0] - __view_get( e__VW.XView, 0 ) > 300);
 			}
 			var warp_route_tooltip = "Major warp route to {0} (x4 travel speed for warp capable crafts)\n\nHold Shift and click Left Mouse Button to see destination.";
 			if (scr_hit(hit_box)){

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -1,8 +1,8 @@
 // Script assets have changed for v2.3.0 see
 // https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
-function set_warp_point_data(){
-	warp_point_hover = true;
-}
+// function set_warp_point_data(){
+// 	warp_point_hover = true;
+// }
 // Main menu movement
 
 function in_camera_view(rect){
@@ -94,8 +94,8 @@ function draw_warp_lanes(){
 	static warp_image=-1;
 	warp_image+=0.5;
 	if warp_image==58 then warp_image = 0;
-	if (!warp_point_hover) then hover_time=0;
-	warp_point_hover = false;
+	// if (!warp_point_hover) then hover_time=0;
+	// warp_point_hover = false;
 	for (var i = 0;i<array_length(routes);i++){
 		draw_set_color(c_gray);
 		route = routes[i];
@@ -140,6 +140,7 @@ function draw_warp_lanes(){
 			if (allow_tooltips && instance_exists(obj_fleet_select)){
 				allow_tooltips = !obj_fleet_select.currently_entered;
 			}
+			var warp_route_tooltip = "Major warp route to {0} (x4 travel speed for warp capable crafts)\n\nHold Shift and click Left Mouse Button to see destination.";
 			if (scr_hit(hit_box)){
 				//TODO centralise this for efficiency so it's only run once at the beggingin of step sequence
 				var star_overlap = false;
@@ -151,19 +152,20 @@ function draw_warp_lanes(){
 				}
 				if (!star_overlap){
 					var to = instance_nearest(route_coords[2],route_coords[3], obj_star);
+					// warp_point_hover = true;
+
 					if (allow_tooltips){
-						tooltip_draw($"Major warp route to {to.name} (4 X travel for warp capable crafts, click to see destination)");
-					}
-					warp_point_hover = true;
-
-					if (array_equals(hover_loc,[route_coords[0] ,route_coords[1]])){
-						hover_time++;
-					} else {
-						hover_loc = [route_coords[0] ,route_coords[1]];
-						hover_time = 0;
+						tooltip_draw(string(warp_route_tooltip, to.name));
 					}
 
-					if (mouse_check_button_pressed(mb_left) || (instance_exists(obj_fleet_select) && hover_time>=15)){
+					// if (array_equals(hover_loc,[route_coords[0] ,route_coords[1]])){
+					// 	hover_time++;
+					// } else {
+					// 	hover_loc = [route_coords[0] ,route_coords[1]];
+					// 	hover_time = 0;
+					// }
+
+					if ((mouse_check_button_pressed(mb_left) && keyboard_check(vk_shift)) /* || (instance_exists(obj_fleet_select) && hover_time>=30) */){
 						set_map_pan_to_loc(to);
 					}
 				}
@@ -183,19 +185,22 @@ function draw_warp_lanes(){
 						break;
 					}
 				}
-				if (!star_overlap){				
-					var to = instance_nearest(route_coords[0] ,route_coords[1], obj_star);
+				if (!star_overlap){
+					var to = instance_nearest(route_coords[0], route_coords[1], obj_star);
+					// warp_point_hover = true;
+
 					if (allow_tooltips){
-						tooltip_draw($"Major warp route to {to.name} (4 X travel for warp capable crafts, click to see destination)");
+						tooltip_draw(string(warp_route_tooltip, to.name));
 					}
-					warp_point_hover = true;
-					if (array_equals(hover_loc,[route_coords[2], route_coords[3]])){
-						hover_time++;
-					} else {
-						hover_loc = [route_coords[2], route_coords[3]];
-						hover_time = 0;
-					}
-					if (mouse_check_button_pressed(mb_left) || (instance_exists(obj_fleet_select) && hover_time>=15)){
+
+					// if (array_equals(hover_loc,[route_coords[2] ,route_coords[3]])){
+					// 	hover_time++;
+					// } else {
+					// 	hover_loc = [route_coords[2] ,route_coords[3]];
+					// 	hover_time = 0;
+					// }
+
+					if ((mouse_check_button_pressed(mb_left) && keyboard_check(vk_shift))/*  || (instance_exists(obj_fleet_select) && hover_time>=30) */){
 						set_map_pan_to_loc(to);
 					}
 				}

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -137,9 +137,9 @@ function draw_warp_lanes(){
 			var hit_box = [route_coords[0]+dist_x-(warp_width/2),route_coords[1]+dist_y-(warp_height/2), route_coords[0]+dist_x+(warp_width/2) ,route_coords[1]+dist_y+(warp_height/2) ];
 			
 			var allow_tooltips = (!instance_exists(obj_star_select))
-			// if (allow_tooltips && instance_exists(obj_fleet_select)){
-			// 	allow_tooltips = !obj_fleet_select.currently_entered;
-			// }
+			if (allow_tooltips && instance_exists(obj_fleet_select)){
+				allow_tooltips = !obj_fleet_select.currently_entered;
+			}
 			var warp_route_tooltip = "Major warp route to {0} (x4 travel speed for warp capable crafts)\n\nHold Shift and click Left Mouse Button to see destination.";
 			if (scr_hit(hit_box)){
 				//TODO centralise this for efficiency so it's only run once at the beggingin of step sequence

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -137,9 +137,9 @@ function draw_warp_lanes(){
 			var hit_box = [route_coords[0]+dist_x-(warp_width/2),route_coords[1]+dist_y-(warp_height/2), route_coords[0]+dist_x+(warp_width/2) ,route_coords[1]+dist_y+(warp_height/2) ];
 			
 			var allow_tooltips = (!instance_exists(obj_star_select))
-			if (allow_tooltips && instance_exists(obj_fleet_select)){
-				allow_tooltips = !obj_fleet_select.currently_entered;
-			}
+			// if (allow_tooltips && instance_exists(obj_fleet_select)){
+			// 	allow_tooltips = !obj_fleet_select.currently_entered;
+			// }
 			var warp_route_tooltip = "Major warp route to {0} (x4 travel speed for warp capable crafts)\n\nHold Shift and click Left Mouse Button to see destination.";
 			if (scr_hit(hit_box)){
 				//TODO centralise this for efficiency so it's only run once at the beggingin of step sequence

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -158,12 +158,12 @@ function draw_warp_lanes(){
 						tooltip_draw(string(warp_route_tooltip, to.name));
 					}
 
-					// if (array_equals(hover_loc,[route_coords[0] ,route_coords[1]])){
-					// 	hover_time++;
-					// } else {
-					// 	hover_loc = [route_coords[0] ,route_coords[1]];
-					// 	hover_time = 0;
-					// }
+					/* if (array_equals(hover_loc,[route_coords[0] ,route_coords[1]])){
+					 	hover_time++;
+					 } else {
+					 	hover_loc = [route_coords[0] ,route_coords[1]];
+					 	hover_time = 0;
+					 }*/
 
 					if ((mouse_check_button_pressed(mb_left) && keyboard_check(vk_shift)) /* || (instance_exists(obj_fleet_select) && hover_time>=30) */){
 						set_map_pan_to_loc(to);


### PR DESCRIPTION
- Disabled automatic warp route screen pan, as it was just obnoxious. Very often it was just sending your screen flying when you didn't need that.
- Changed manual pan trigger from just clicking to SHIFT+click, to prevent missclicks.
- Fixed tooltip flipping not working on the star map.