### PR TITLE
fix: Chapter Master and Captains missing in various places

### DIFF
--- a/objects/obj_drop_select/Alarm_1.gml
+++ b/objects/obj_drop_select/Alarm_1.gml
@@ -53,42 +53,45 @@ if (arright=false) then formation_current=formation_possible[1];
 
 // show_message("Star: "+string(p_target.name)+", Planet: "+string(planet_number));
 
-var co,i,unit;co=-1;i=0;
-repeat(11){co+=1;i=0;
-    repeat(300){i+=1;
-        if (i<=100){if (obj_ini.veh_loc[co][i]=p_target.name) and (obj_ini.veh_wid[co][i]=planet_number) and (attack=1){
-            if (obj_ini.veh_role[co][i]="Land Speeder") then l_speeders+=1;
-            if (obj_ini.veh_role[co][i]="Rhino") then l_rhinos+=1;
-            if (obj_ini.veh_role[co][i]="Whirlwind") then l_whirls+=1;
-            if (obj_ini.veh_role[co][i]="Predator") then l_predators+=1;
-            if (obj_ini.veh_role[co][i]="Land Raider") then l_raiders+=1;
-        }}
-        unit=obj_ini.TTRPG[co][i];
-        if (unit.name()=="") then continue;
-        if (obj_ini.loc[co][i]=p_target.name) and (unit.planet_location==planet_number){
-            if ((attack=0) and (string_count("Bike",obj_ini.role[co][i])=0)) or (attack=1){
-                if (unit.role()="Chapter Master") then l_master+=1;
-                if (unit.role()=obj_ini.role[100][2]) then l_honor+=1;
-                if (unit.role()=obj_ini.role[100][5]) then l_capts+=1;
-                if (unit.role()="Champion") then l_champions+=1;
-                
-                if (string_count("Bike",obj_ini.role[co][i])=0) or (attack=0){
-                    if (obj_ini.role[co][i]=obj_ini.role[100][11]) then l_mahreens+=1;
+var unit;
+for (var co = 1; co <= 10; co++) {
+    for (var i = 0; i <= 300; i++) {
+        if (i <= 100) {
+            if (obj_ini.veh_loc[co][i] = p_target.name) && (obj_ini.veh_wid[co][i] = planet_number) && (attack = 1) {
+                if (obj_ini.veh_role[co][i] = "Land Speeder") then l_speeders += 1;
+                if (obj_ini.veh_role[co][i] = "Rhino") then l_rhinos += 1;
+                if (obj_ini.veh_role[co][i] = "Whirlwind") then l_whirls += 1;
+                if (obj_ini.veh_role[co][i] = "Predator") then l_predators += 1;
+                if (obj_ini.veh_role[co][i] = "Land Raider") then l_raiders += 1;
+            }
+        }
+        unit = obj_ini.TTRPG[co][i];
+        if (unit.name() == "") then
+        continue;
+        if (obj_ini.loc[co][i] = p_target.name) && (unit.planet_location == planet_number) {
+            if ((attack = 0) && (string_count("Bike", obj_ini.role[co][i]) = 0)) || (attack = 1) {
+                if (unit.role() = "Chapter Master") then l_master += 1;
+                if (unit.role() = obj_ini.role[100][2]) then l_honor += 1;
+                if (unit.role() = obj_ini.role[100][5]) then l_capts += 1;
+                if (unit.role() = "Champion") then l_champions += 1;
+
+                if (string_count("Bike", obj_ini.role[co][i]) = 0) || (attack = 0) {
+                    if (obj_ini.role[co][i] = obj_ini.role[100][11]) then l_mahreens += 1;
                     if (unit.IsSpecialist("rank_and_file")) then l_mahreens++
-                    if (obj_ini.role[co][i]=obj_ini.role[100][3]) then l_veterans+=1;
+                    if (obj_ini.role[co][i] = obj_ini.role[100][3]) then l_veterans += 1;
                 }
-                if (string_count("Bike",obj_ini.role[co][i])>0) and (attack=1){
-                    if (obj_ini.role[co][i]=obj_ini.role[100][11]) then l_bikes+=1;
+                if (string_count("Bike", obj_ini.role[co][i]) > 0) && (attack = 1) {
+                    if (obj_ini.role[co][i] = obj_ini.role[100][11]) then l_bikes += 1;
                     if (unit.IsSpecialist("rank_and_file")) then l_bikes++
-                    if (obj_ini.role[co][i]=obj_ini.role[100][3]) then l_bikes+=1;
+                    if (obj_ini.role[co][i] = obj_ini.role[100][3]) then l_bikes += 1;
                 }
-                
-                if (unit.role()=obj_ini.role[100][4]) then l_terminators+=1;
-                if (unit.role()=obj_ini.role[100][6]) then l_dreads+=1;
-                if (unit.IsSpecialist("chap", true)) then l_chaplains+=1;
-                if (unit.IsSpecialist("libs", true)) then l_psykers+=1;
-                if (unit.IsSpecialist("apoth", true)) then l_apothecaries+=1;
-                if (unit.IsSpecialist("forge", true)) then l_techmarines+=1;
+
+                if (unit.role() = obj_ini.role[100][4]) then l_terminators += 1;
+                if (unit.role() = obj_ini.role[100][6]) then l_dreads += 1;
+                if (unit.IsSpecialist("chap", true)) then l_chaplains += 1;
+                if (unit.IsSpecialist("libs", true)) then l_psykers += 1;
+                if (unit.IsSpecialist("apoth", true)) then l_apothecaries += 1;
+                if (unit.IsSpecialist("forge", true)) then l_techmarines += 1;
             }
         }
     }

--- a/objects/obj_drop_select/Alarm_1.gml
+++ b/objects/obj_drop_select/Alarm_1.gml
@@ -54,7 +54,7 @@ if (arright=false) then formation_current=formation_possible[1];
 // show_message("Star: "+string(p_target.name)+", Planet: "+string(planet_number));
 
 var unit;
-for (var co = 1; co <= 10; co++) {
+for (var co = 0; co <= 10; co++) {
     for (var i = 0; i <= 300; i++) {
         if (i <= 100) {
             if (obj_ini.veh_loc[co][i] = p_target.name) && (obj_ini.veh_wid[co][i] = planet_number) && (attack = 1) {

--- a/objects/obj_drop_select/Alarm_5.gml
+++ b/objects/obj_drop_select/Alarm_5.gml
@@ -102,7 +102,8 @@ for (var i=0; i<3600; i++) {
 }
 
 var ships_selected=0;
-for (var i=0; i<31; i++) {
+var ships_len = array_length(ship_all);
+for (var i = 0; i < ships_len; i++) {
     if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
 }
 if (ship_all[500]=1) and (attack=1) then scr_battle_roster(p_target.name,obj_controller.selecting_planet,true);

--- a/objects/obj_drop_select/Alarm_6.gml
+++ b/objects/obj_drop_select/Alarm_6.gml
@@ -77,9 +77,10 @@ repeat(3600){
 
 // Iterates through all selected "ships" (max 30), including the planet (Local on the drop menu), 
 // and fills the battle roster with any marines found.
-var i;i=-1;ships_selected=0;
-repeat(31){
-    i+=1;if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
+ships_selected=0;
+var ships_len = array_length(ship_all);
+for (var i = 0; i < ships_len; i++) {
+    if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
 }
 //ship_all[500] equals "Local" status on the drop menu
 if (ship_all[500]=1) and (attack=1) then scr_battle_roster(p_target.name,obj_controller.selecting_planet,true);

--- a/objects/obj_drop_select/Draw_0.gml
+++ b/objects/obj_drop_select/Draw_0.gml
@@ -495,9 +495,10 @@ if (scr_hit(xx+954,yy+556,xx+1043,yy+579)=true){
         
         // Iterates through all selected "ships" (max 30), including the planet (Local on the drop menu), 
         // and fills the battle roster with any marines found.
-        var i;i=-1;ships_selected=0;
-        repeat(31){
-            i+=1;if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
+        ships_selected=0;
+        var ships_len = array_length(ship_all);
+        for (var i = 0; i < ships_len; i++) {
+            if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
         }
 		//ship_all[500] equals "Local" status on the drop menu
 		if (ship_all[500]=1) and (attack=1) then scr_battle_roster(p_target.name,planet_number,true);

--- a/objects/obj_drop_select/Mouse_56.gml
+++ b/objects/obj_drop_select/Mouse_56.gml
@@ -67,55 +67,92 @@ if (obj_controller.cooldown<=0){
 
 
 
-if (obj_controller.cooldown<=0){
-    if (mouse_x>=xx+456) and (mouse_y>=yy+378) and (mouse_x<xx+519) and (mouse_y<yy+403){
-        instance_destroy();obj_controller.cooldown=8000;
+if (obj_controller.cooldown <= 0) {
+    if (mouse_x >= xx + 456) && (mouse_y >= yy + 378) && (mouse_x < xx + 519) && (mouse_y < yy + 403) {
+        instance_destroy();
+        obj_controller.cooldown = 8000;
     }
-    
-    if (mouse_x>=xx+76) and (mouse_y>=yy+82) and (mouse_x<xx+102) and (mouse_y<yy+95){
-        var onceh;once=0;i=0;
-        if (all_sel=0) and (onceh=0){
-            repeat(30){i+=1;
-                if (ship[i]!="") and (ship_all[i]=0){ship_all[i]=1;scr_drop_fiddle(ship_ide[i],true,i,attack);}
+
+    if (mouse_x >= xx + 76) && (mouse_y >= yy + 82) && (mouse_x < xx + 102) && (mouse_y < yy + 95) {
+        var onceh;
+        once = 0;
+        i = 0;
+        if (all_sel = 0) && (onceh = 0) {
+            var ships_len = array_length(ship);
+            for (var i = 0; i < ships_len; i++) {
+                if (ship[i] != "") && (ship_all[i] = 0) {
+                    ship_all[i] = 1;
+                    scr_drop_fiddle(ship_ide[i], true, i, attack);
+                }
             }
-            if (ship_all[500]=0) and (l_size>0){ship_all[500]=1;add_ground=1;}
-            onceh=1;all_sel=1;
+            if (ship_all[500] = 0) && (l_size > 0) {
+                ship_all[500] = 1;
+                add_ground = 1;
+            }
+            onceh = 1;
+            all_sel = 1;
         }
-        if (all_sel=1) and (onceh=0){
-            repeat(30){i+=1;
-                if (ship[i]!="") and (ship_all[i]=1){ship_all[i]=0;scr_drop_fiddle(ship_ide[i],false,i,attack);}
+        if (all_sel = 1) && (onceh = 0) {
+            var ships_len = array_length(ship);
+            for (var i = 0; i < ships_len; i++) {
+                if (ship[i] != "") && (ship_all[i] = 1) {
+                    ship_all[i] = 0;
+                    scr_drop_fiddle(ship_ide[i], false, i, attack);
+                }
             }
-            if (ship_all[500]=1) and (l_size>0){ship_all[500]=0;add_ground=-1;}
-            onceh=1;all_sel=0;
+            if (ship_all[500] = 1) && (l_size > 0) {
+                ship_all[500] = 0;
+                add_ground = -1;
+            }
+            onceh = 1;
+            all_sel = 0;
         }
     }
 }
 
+if (add_ground = 1) {
+    ships_selected += 1;
+    master += l_master;
+    honor += l_honor;
+    capts += l_capts;
+    mahreens += l_mahreens;
+    veterans += l_veterans;
+    terminators += l_terminators;
+    dreads += l_dreads;
+    chaplains += l_chaplains;
+    psykers += l_psykers;
+    apothecaries += l_apothecaries;
+    techmarines += l_techmarines;
+    champions += l_champions;
 
-
-if (add_ground=1){ships_selected+=1;
-    master+=l_master;honor+=l_honor;
-    capts+=l_capts;mahreens+=l_mahreens;
-    veterans+=l_veterans;terminators+=l_terminators;
-    dreads+=l_dreads;chaplains+=l_chaplains;
-    psykers+=l_psykers;apothecaries+=l_apothecaries;
-    techmarines+=l_techmarines;champions+=l_champions;
-    
-    bikes+=l_bikes;rhinos+=l_rhinos;
-    whirls+=l_whirls;predators+=l_predators;
-    raiders+=l_raiders;speeders+=l_speeders;
+    bikes += l_bikes;
+    rhinos += l_rhinos;
+    whirls += l_whirls;
+    predators += l_predators;
+    raiders += l_raiders;
+    speeders += l_speeders;
 }
-if (add_ground=-1){ships_selected-=1;
-    master-=l_master;honor-=l_honor;
-    capts-=l_capts;mahreens-=l_mahreens;
-    veterans-=l_veterans;terminators-=l_terminators;
-    dreads-=l_dreads;chaplains-=l_chaplains;
-    psykers-=l_psykers;apothecaries-=l_apothecaries;
-    techmarines-=l_techmarines;champions-=l_champions;
-    
-    bikes-=l_bikes;rhinos-=l_rhinos;
-    whirls-=l_whirls;predators-=l_predators;
-    raiders-=l_raiders;speeders-=l_speeders;
+if (add_ground = -1) {
+    ships_selected -= 1;
+    master -= l_master;
+    honor -= l_honor;
+    capts -= l_capts;
+    mahreens -= l_mahreens;
+    veterans -= l_veterans;
+    terminators -= l_terminators;
+    dreads -= l_dreads;
+    chaplains -= l_chaplains;
+    psykers -= l_psykers;
+    apothecaries -= l_apothecaries;
+    techmarines -= l_techmarines;
+    champions -= l_champions;
+
+    bikes -= l_bikes;
+    rhinos -= l_rhinos;
+    whirls -= l_whirls;
+    predators -= l_predators;
+    raiders -= l_raiders;
+    speeders -= l_speeders;
 }
 
 
@@ -224,9 +261,10 @@ if (obj_controller.cooldown<=0) and (once_only=0){// Need to change max_ships to
             }
         }
         
-        var i;i=-1;ships_selected=0;
-        repeat(31){
-            i+=1;if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
+        ships_selected=0;
+        var ships_len = array_length(ship_all);
+        for (var i = 0; i < ships_len; i++) {
+            if (ship_all[i]!=0) then scr_battle_roster(ship[i],ship_ide[i],false);
         }
         if (ship_all[500]=1) then scr_battle_roster(p_target.name,planet_number,true);
         

--- a/objects/obj_enunit/Alarm_0.gml
+++ b/objects/obj_enunit/Alarm_0.gml
@@ -12,7 +12,7 @@ var leftest,charge=0,enemy2=0,chapter_fuck=1,unit;
 // with(obj_pnunit){if (x<-4000) or (defenses=1) then instance_deactivate_object(id);}
 
 if (!flank){
-    leftest=get_leftmost(obj_enunit);// Left most enunit
+    leftest=get_leftmost(obj_enunit, false);// Left most enunit
     enemy=get_rightmost();// Right most enemy
     enemy2=enemy;
     if (enemy=="none"||leftest=="none"){
@@ -23,7 +23,7 @@ if (!flank){
     
     
     if (leftest.id=self.id) and (!instance_exists(obj_nfort)){
-        if (position_empty(x-10,y)) and (point_distance(x,y,enemy.x,enemy.y)>10){
+        if (position_empty(x-10,y)) and (point_distance(x,y,enemy.x,enemy.y)>=10){
             with(obj_enunit){
                 move_unit_block("west");
             }
@@ -318,12 +318,14 @@ if __b__
 
 
 
-var leftest,charge,enemy2;charge=0;enemy2=0;
+var leftest,charge=0,enemy2=0;
 
-with(obj_pnunit){if (x<-4000) then instance_deactivate_object(id);}
+with(obj_pnunit){
+    if (x<-4000) then instance_deactivate_object(id);
+}
 
 if (flank=0){
-    leftest=get_leftmost(obj_enunit);// Left most enunit
+    leftest=get_leftmost(obj_enunit, false);// Left most enunit
     enemy=instance_nearest(4000,y,obj_pnunit);// Right most enemy
     enemy2=enemy;
     // if (collision_point(x-10,y,obj_pnunit,0,1)) then engaged=1;
@@ -331,7 +333,9 @@ if (flank=0){
     if (leftest.id=self.id) and (!instance_exists(obj_nfort)){
         // instance_deactivate_object(obj_cursor);
         if (position_empty(x-10,y)){
-            with(obj_enunit){x-=10;}
+            with(obj_enunit){
+                x-=10;
+            }
         }
     }
     // instance_activate_object(obj_cursor);
@@ -341,7 +345,9 @@ if (flank=1){
     enemy2=enemy;
     // if (collision_point(x+10,y,obj_pnunit,0,1)) then engaged=1;
     // if (!collision_point(x+10,y,obj_pnunit,0,1)) then engaged=0;
-    if (position_empty(x+10,y)) then x+=10;
+    if (position_empty(x+10,y)){
+        move_unit_block();
+    }
     
     if (!position_empty(x+10,y)) then engaged=1;// Quick smash
     // instance_activate_object(obj_cursor);

--- a/objects/obj_enunit/Step_0.gml
+++ b/objects/obj_enunit/Step_0.gml
@@ -29,8 +29,8 @@ if (highlight2!=highlight){
     if (obj_ncombat.enemy = 1) {
         var variety, variety_num, stop, sofar, compl, vas;
         stop = 0;
-        variety = 0;
-        variety_num = 0;
+        variety = [];
+        variety_num = [];
         sofar = 0;
         compl = "";
         vas = "";

--- a/objects/obj_enunit/Step_0.gml
+++ b/objects/obj_enunit/Step_0.gml
@@ -16,8 +16,9 @@ if (highlight2!=highlight){
     highlight2=highlight;highlight3="";
     
     if (obj_ncombat.enemy!=1){
-        var i,stop;i=0;stop=0;
-        repeat(70){i+=1;
+        var stop;stop=0;
+        var dudes_len = array_length(dudes_num);
+        for(var i = 0; i < dudes_len; i++) {
             if (stop=0){
                 if (dudes_num[i]>0) and (dudes_num[i+1]>0) then highlight3+=string(dudes_num[i])+"x "+string(dudes[i])+", ";
                 if (dudes_num[i]>0) and (dudes_num[i+1]<=0){highlight3+=string(dudes_num[i])+"x "+string(dudes[i])+".  ";stop=1;}
@@ -25,36 +26,51 @@ if (highlight2!=highlight){
         }
     }
     
-    if (obj_ncombat.enemy=1){
-        var variety,variety_num,i,q,stop,sofar,compl,vas;
-        i=-1;q=0;stop=0;variety=0;variety_num=0;sofar=0;compl="";vas="";
-        
-        q=-1;repeat(800){q+=1;variety[q]="";variety_num[q]=0;}
-        q=0;repeat(700){q+=1;
-            if (dudes[q]!="") and (string_count(string(dudes[q])+"|",compl)=0){
-                compl+=string(dudes[q])+"|";sofar+=1;
-                variety[sofar]=dudes[q];
-                variety_num[sofar]=0;
+    if (obj_ncombat.enemy = 1) {
+        var variety, variety_num, stop, sofar, compl, vas;
+        stop = 0;
+        variety = 0;
+        variety_num = 0;
+        sofar = 0;
+        compl = "";
+        vas = "";
+
+        var variety_len = array_length(variety);
+        for (var q = 0; q < variety_len; q++) {
+            variety[q] = "";
+            variety_num[q] = 0;
+        }
+        var dudes_len = array_length(dudes);
+        for (var q = 0; q < dudes_len; q++) {
+            if (dudes[q] != "") and(string_count(string(dudes[q]) + "|", compl) = 0) {
+                compl += string(dudes[q]) + "|";
+                variety[sofar] = dudes[q];
+                variety_num[sofar] = 0;
+                sofar += 1;
             }
         }
-        q=0;repeat(700){q+=1;
-            if (dudes[q]!=""){i=0;
-                repeat(50){i+=1;
-                    if (dudes[q]=variety[i]) then variety_num[i]+=dudes_num[q];
+        var dudes_len = array_length(dudes);
+        for (var q = 0; q < dudes_len; q++) {
+            if (dudes[q] != "") {
+                var variety_len = array_length(variety);
+                for (var i = 0; i < variety_len; i++) {
+                    if (dudes[q] = variety[i]) then variety_num[i] += dudes_num[q];
                 }
             }
-            
+
         }
-        i=0;stop=0;
-        repeat(70){i+=1;
-            if (stop=0){
-                if (variety_num[i]>0) and (variety_num[i+1]>0) then highlight3+=string(variety_num[i])+"x "+string(variety[i])+", ";
-                if (variety_num[i]>0) and (variety_num[i+1]<=0){highlight3+=string(variety_num[i])+"x "+string(variety[i])+".  ";stop=1;}
+        stop = 0;
+        var variety_num_len = array_length(variety_num);
+        for (var i = 0; i < variety_num_len; i++) {
+            if (stop = 0) {
+                if (variety_num[i] > 0) and(variety_num[i + 1] > 0) then highlight3 += string(variety_num[i]) + "x " + string(variety[i]) + ", ";
+                if (variety_num[i] > 0) and(variety_num[i + 1] <= 0) {
+                    highlight3 += string(variety_num[i]) + "x " + string(variety[i]) + ".  ";
+                    stop = 1;
+                }
             }
         }
-    }
-    
-    
+    } 
 }
 
 

--- a/objects/obj_ncombat/Alarm_2.gml
+++ b/objects/obj_ncombat/Alarm_2.gml
@@ -4,16 +4,27 @@ enemy_max=enemy_forces;
 
 instance_activate_object(obj_enunit);
 
-if (dropping=1){
-    repeat(10){
-        var mm=instance_nearest(5000,240,obj_pnunit);
-        if (!collision_point(mm.x+10,mm.y,obj_enunit,0,1)) then with(obj_pnunit){
-            x+=10;
+if (dropping){
+    var _player_front_row=get_rightmost();
+    if (_player_front_row!="none"){
+        if (!collision_point(_player_front_row.x+10,_player_front_row.y,obj_enunit,0,1)) then with(obj_pnunit){
+            var _enemy_front =  get_leftmost(obj_enunit, false);
+            if (_enemy_front!="none"){
+                _player_front_row.x = _enemy_front.x-10;
+            }
         }
     }
     repeat(10){
         with(obj_enunit){
-            if (!collision_point(x-10,y,obj_pnunit,0,1)) and (!collision_point(x-10,y,obj_enunit,0,1)) then x-=10;
+            if (!flank){
+                if (!collision_point(x-10,y,obj_pnunit,0,1)) and (!collision_point(x-10,y,obj_enunit,0,1)){
+                    move_unit_block("west");
+                }
+            } else {
+                if (!collision_point(x+10,y,obj_pnunit,0,1)) and (!collision_point(x+10,y,obj_enunit,0,1)){
+                    move_unit_block("east");
+                }
+            }
         }
     }
 }

--- a/objects/obj_ncombat/Alarm_5.gml
+++ b/objects/obj_ncombat/Alarm_5.gml
@@ -9,11 +9,14 @@ alarm[8]=999999;
 // show_message("Final Deaths: "+string(final_deaths));
 
 
+if (turn_count >= 50){
+    part1 = "Your forces make a fighting retreat \n"
+}
 // check for wounded marines here to finish off, if defeated defending
 var roles = obj_ini.role[100];
 var ground_mission = (instance_exists(obj_ground_mission));
 if (final_deaths+final_command_deaths>0){
-    part1=$"Marines Lost: {final_deaths+final_command_deaths}";
+    part1+=$"Marines Lost: {final_deaths+final_command_deaths}";
     if (units_saved > 0){
         part1+=$" ({roles[Role.APOTHECARY]}{apothecaries_alive>1?"s":""} prevented the death of {units_saved})";
     }
@@ -28,7 +31,10 @@ if (final_deaths+final_command_deaths>0){
     part2=string_delete(part2,string_length(part2)-1,2);
     part2+=".";i=0;
     
-    if (injured>0){newline=part8;scr_newtext();}
+    if (injured>0){
+        newline=part8;
+        scr_newtext();
+    }
     newline=part1;
     scr_newtext();
     newline=part2;

--- a/objects/obj_ncombat/Alarm_7.gml
+++ b/objects/obj_ncombat/Alarm_7.gml
@@ -267,12 +267,15 @@ if (scr_role_count("Chapter Master","")=0){
 }
 
 
+if (turn_count < 20){
+    if (defeat=0) and (threat>=4) then scr_recent("battle_victory",string(battle_loc)+" "+scr_roman(battle_id),enemy);
 
-if (defeat=0) and (threat>=4) then scr_recent("battle_victory",string(battle_loc)+" "+scr_roman(battle_id),enemy);
 
 
-
-if (defeat=1) and (final_deaths+final_command_deaths>=10) then scr_recent("battle_defeat",string(enemy),final_deaths+final_command_deaths);
+    if (defeat=1) and (final_deaths+final_command_deaths>=10) then scr_recent("battle_defeat",string(enemy),final_deaths+final_command_deaths);
+} else {
+    scr_recent("battle_defeat",string(enemy),final_deaths+final_command_deaths);
+}
 
 
 

--- a/objects/obj_ncombat/Create_0.gml
+++ b/objects/obj_ncombat/Create_0.gml
@@ -9,7 +9,7 @@ repeat(15){co+=1;i=-1;
     }
 }co=0;i=0;hue=0;
 
-
+turn_count = 0;
 debugl("Ground Combat Started");
 
 audio_stop_sound(snd_royal);

--- a/objects/obj_ncombat/KeyPress_13.gml
+++ b/objects/obj_ncombat/KeyPress_13.gml
@@ -36,6 +36,11 @@ if (started=3){
 
 // if (done>=1) then exit;
 
+
+
+if (turn_count >= 50){
+    started=2;
+}
 if ((started=2) or (started=4)){
     instance_activate_object(obj_pnunit);
     instance_activate_object(obj_enunit);
@@ -99,6 +104,7 @@ if (timer_stage=1) or (timer_stage=5){
         if (instance_exists(obj_pnunit)){
             obj_pnunit.alarm[3]=2;
             obj_pnunit.alarm[1]=3;
+            turn_count++;
             obj_pnunit.alarm[0]=4;
         }
         // alarm[9]=5;
@@ -111,6 +117,7 @@ if (timer_stage=1) or (timer_stage=5){
         }
         if (instance_exists(obj_pnunit)){
             obj_pnunit.alarm[1]=1;
+            turn_count++;
         }
     }
     messages=0;messages_to_show=8;largest=0;random_messages=0;priority=0;messages_shown=0;
@@ -127,6 +134,7 @@ else if (timer_stage=3){
     if (enemy!=6){
         if (instance_exists(obj_pnunit)){
             obj_pnunit.alarm[1]=1;
+            turn_count++;
         }
         if (instance_exists(obj_enunit)){
             obj_enunit.alarm[1]=2;
@@ -142,6 +150,7 @@ else if (timer_stage=3){
         if (instance_exists(obj_pnunit)){
             obj_pnunit.alarm[3]=2;
             obj_pnunit.alarm[1]=3;
+            turn_count++;
             obj_pnunit.alarm[0]=4;
             turns+=1;
         }

--- a/scripts/scr_drop_fiddle/scr_drop_fiddle.gml
+++ b/scripts/scr_drop_fiddle/scr_drop_fiddle.gml
@@ -13,110 +13,141 @@ function scr_drop_fiddle(argument0, argument1, argument2, argument3) {
 
 	if (attacking=0) then vgood=0;
 
-	if (argument0>0) and (argument1=true){// Adding marines to the drop roster
-	    ship_all[argument2]=1;
-    	var unit;
-	    repeat(3500){
-	        if (good=1){para=true;
-	            i+=1;if (i>300){i=1;comp+=1;}
-	            if (comp>10) then good=0;
-	        }
-	        if (good=1) and (vgood=1) and (i<=100) and (vehy=1) and (obj_ini.veh_lid[comp][i]=argument0){
-	            veh_fighting[comp][i]=1;
-	            if (obj_ini.veh_role[comp][i]="Land Speeder") then speeders+=1;
-	            if (obj_ini.veh_role[comp][i]="Rhino") then rhinos+=1;
-	            if (obj_ini.veh_role[comp][i]="Whirlwind") then whirls+=1;
-	            if (obj_ini.veh_role[comp][i]="Predator") then predators+=1;
-	            if (obj_ini.veh_role[comp][i]="Land Raider") then raiders+=1;
-	        }
-	        if (good=1){
-	        	unit = fetch_unit([comp,i]);
-	            if (obj_ini.race[comp][i]!=0) and (unit.ship_location=argument0) /*and (string_count("Aspirant",obj_ini.role[comp][i])=0)*/ and (obj_ini.god[comp][i]<10) and ((string_count("Bike",obj_ini.mobi[comp][i])=0) or (vehy=1)) and (para=true){// Man
-	                ship_use[argument2]+=1;fighting[comp][i]=1;
-                
-	                if (obj_ini.role[comp][i]="Chapter Master"){master=1;ship_use[argument2]+=1;}
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][2]) then honor+=1;
-	                if (obj_ini.role[comp][i]="Champion") then champions+=1;
-                
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][5]) then capts+=1;
-	                if (unit.IsSpecialist("chap", true)) then chaplains+=1;
-                	if (unit.IsSpecialist("libs", true)) then psykers+=1;
-                	if (unit.IsSpecialist("apoth", true)) then apothecaries+=1;
-                	if (unit.IsSpecialist("forge", true)) then techmarines+=1;
-                
-	                if (obj_ini.role[comp][i]="Death Company") and (string_count("Dreadnought",obj_ini.armour[comp][i])=0) then mahreens+=1;
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][4]) then terminators+=1;
-	                if ((obj_ini.role[comp][i]=obj_ini.role[100][6]) or (obj_ini.role[comp][i]="Venerable "+string(obj_ini.role[100][6])) or (string_count("Dreadnought",obj_ini.armour[comp][i])=1)) and (assassinate=false) then dreads+=1;
-                
-	                if (string_count("Bike",obj_ini.mobi[comp][i])=0){
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][11]) then mahreens+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][12]) then mahreens+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][8]) or (obj_ini.role[comp][i]=obj_ini.role[100][10]) or (obj_ini.role[comp][i]=obj_ini.role[100][9]) then mahreens+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][3]) then veterans+=1;
-	                }
-	                if (string_count("Bike",obj_ini.mobi[comp][i])>0) and (vehy=1){
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][11]) then bikes+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][12]) then bikes+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][8]) or (obj_ini.role[comp][i]=obj_ini.role[100][10]) or (obj_ini.role[comp][i]=obj_ini.role[100][9]) then bikes+=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][3]) then bikes+=1;
-	                }
-	            }
-	        }
-    
-	    }
+	if (argument0 > 0 && argument1 == true) { // Adding marines to the drop roster
+		ship_all[argument2] = 1;
+		var unit;
+		for (var i = 0; i <= 3500; i++) {
+			if (good == 1) {
+				para = true;
+				if (i > 300) {
+					i = 0;
+					comp++;
+				}
+				if (comp > 10) then good = 0;
+			}
+	
+			if (good == 1 && vgood == 1 && i <= 100 && vehy == 1 && obj_ini.veh_lid[comp][i] == argument0) {
+				veh_fighting[comp][i] = 1;
+				if (obj_ini.veh_role[comp][i] == "Land Speeder") then speeders++;
+				if (obj_ini.veh_role[comp][i] == "Rhino") then rhinos++;
+				if (obj_ini.veh_role[comp][i] == "Whirlwind") then whirls++;
+				if (obj_ini.veh_role[comp][i] == "Predator") then predators++;
+				if (obj_ini.veh_role[comp][i] == "Land Raider") then raiders++;
+			}
+	
+			if (good == 1) {
+				unit = fetch_unit([comp, i]);
+				if (obj_ini.race[comp][i] != 0 && unit.ship_location == argument0 && obj_ini.god[comp][i] < 10 && 
+					(string_count("Bike", obj_ini.mobi[comp][i]) == 0 || vehy == 1) && para == true) { // Man
+					ship_use[argument2]++;
+					fighting[comp][i] = 1;
+	
+					if (obj_ini.role[comp][i] == "Chapter Master") {
+						master = 1;
+						ship_use[argument2]++;
+					}
+					if (obj_ini.role[comp][i] == obj_ini.role[100][2]) then honor++;
+					if (obj_ini.role[comp][i] == "Champion") then champions++;
+	
+					if (obj_ini.role[comp][i] == obj_ini.role[100][5]) then capts++;
+					if (unit.IsSpecialist("chap", true)) then chaplains++;
+					if (unit.IsSpecialist("libs", true)) then psykers++;
+					if (unit.IsSpecialist("apoth", true)) then apothecaries++;
+					if (unit.IsSpecialist("forge", true)) then techmarines++;
+	
+					if (obj_ini.role[comp][i] == "Death Company" && string_count("Dreadnought", obj_ini.armour[comp][i]) == 0) then mahreens++;
+					if (obj_ini.role[comp][i] == obj_ini.role[100][4]) then terminators++;
+					if (((obj_ini.role[comp][i] == obj_ini.role[100][6]) || 
+						(obj_ini.role[comp][i] == "Venerable " + string(obj_ini.role[100][6])) || 
+						string_count("Dreadnought", obj_ini.armour[comp][i]) == 1) && assassinate == false) then dreads++;
+	
+					if (string_count("Bike", obj_ini.mobi[comp][i]) == 0) {
+						if (obj_ini.role[comp][i] == obj_ini.role[100][11]) then mahreens++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][12]) then mahreens++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][8] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][10] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][9]) then mahreens++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][3]) then veterans++;
+					}
+					if (string_count("Bike", obj_ini.mobi[comp][i]) > 0 && vehy == 1) {
+						if (obj_ini.role[comp][i] == obj_ini.role[100][11]) then bikes++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][12]) then bikes++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][8] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][10] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][9]) then bikes++;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][3]) then bikes++;
+					}
+				}
+			}
+		}
 	}
+	
+	if (argument0 > 0 && argument1 == false) { // Removing marines from the drop roster
+		ship_all[argument2] = 0;
+	
+		for (var i = 0; i <= 3500; i++) {
+			if (good == 1) {
+				if (i > 300) {
+					i = 0;
+					comp += 1;
+				}
+				if (comp > 10) then good = 0;
+			}
+	
+			if (good == 1 && i <= 100 && vehy == 1 && obj_ini.veh_lid[comp][i] == argument0) {
+				veh_fighting[comp][i] = 0;
+				if (obj_ini.veh_role[comp][i] == "Land Speeder") then speeders--;
+				if (obj_ini.veh_role[comp][i] == "Rhino") then rhinos--;
+				if (obj_ini.veh_role[comp][i] == "Whirlwind") then whirls--;
+				if (obj_ini.veh_role[comp][i] == "Predator") then predators--;
+				if (obj_ini.veh_role[comp][i] == "Land Raider") then raiders--;
+			}
 
-	if (argument0>0) and (argument1=false){// Removing marines from the drop roster
-	    ship_all[argument2]=0;
-
-	    repeat(3500){
-	        if (good=1){
-	            i+=1;if (i>300){i=1;comp+=1;}
-	            if (comp>10) then good=0;
-	        }
-	        if (good=1) and (i<=100) and (vehy=1) and (obj_ini.veh_lid[comp][i]=argument0){
-	            veh_fighting[comp][i]=0;
-	            if (obj_ini.veh_role[comp][i]="Land Speeder") then speeders-=1;
-	            if (obj_ini.veh_role[comp][i]="Rhino") then rhinos-=1;
-	            if (obj_ini.veh_role[comp][i]="Whirlwind") then whirls-=1;
-	            if (obj_ini.veh_role[comp][i]="Predator") then predators-=1;
-	            if (obj_ini.veh_role[comp][i]="Land Raider") then raiders-=1;
-	        }
-	        if (good=1){
-	        	unit = fetch_unit([comp,i]);
-	            if (obj_ini.race[comp][i]!=0) and (unit.ship_location=argument0) /* and (string_count("Aspirant",obj_ini.role[comp][i])=0) */ and (obj_ini.god[comp][i]<10) and ((string_count("Bike",obj_ini.mobi[comp][i])=0) or (vehy=1)){// Man
-	                ship_use[argument2]-=1;fighting[comp][i]=0;
-                            
-	                if (obj_ini.role[comp][i]="Chapter Master"){master=0;ship_use[argument2]-=1;}
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][2]) then honor-=1;
-	                if (obj_ini.role[comp][i]="Champion") then champions-=1;
-                
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][5]) then capts-=1;
-	                if (unit.IsSpecialist("chap", true)) then chaplains-=1;
-	                if (unit.IsSpecialist("libs", true)) then psykers-=1;
-	                if (unit.IsSpecialist("apoth", true)) then apothecaries-=1;
-	                if (unit.IsSpecialist("forge", true)) then techmarines-=1;
-                
-	                if (obj_ini.role[comp][i]="Death Company") and (string_count("Dreadnought",obj_ini.armour[comp][i])=0) then mahreens-=1;
-	                if (obj_ini.role[comp][i]=obj_ini.role[100][4]) then terminators-=1;
-	                if ((obj_ini.role[comp][i]=obj_ini.role[100][6]) or (obj_ini.role[comp][i]="Venerable "+string(obj_ini.role[100][6])) or (string_count("Dreadnought",obj_ini.armour[comp][i])=1)) and (assassinate=false) then dreads-=1;
-                
-	                if (string_count("Bike",obj_ini.mobi[comp][i])=0){
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][11]) then mahreens-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][12]) then mahreens-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][8]) or (obj_ini.role[comp][i]=obj_ini.role[100][10]) or (obj_ini.role[comp][i]=obj_ini.role[100][9]) then mahreens-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][3]) then veterans-=1;
-	                }
-	                if (string_count("Bike",obj_ini.mobi[comp][i])>0) and (vehy=1){
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][11]) then bikes-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][12]) then bikes-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][8]) or (obj_ini.role[comp][i]=obj_ini.role[100][10]) or (obj_ini.role[comp][i]=obj_ini.role[100][9]) then bikes-=1;
-	                    if (obj_ini.role[comp][i]=obj_ini.role[100][3]) then bikes-=1;
-	                }
-	            }
-	        }
-    
-	    }
+			if (good == 1) {
+				unit = fetch_unit([comp, i]);
+				if (obj_ini.race[comp][i] != 0 && unit.ship_location == argument0 && obj_ini.god[comp][i] < 10 && 
+					(string_count("Bike", obj_ini.mobi[comp][i]) == 0 || vehy == 1)) { // Man
+					ship_use[argument2]--;
+					fighting[comp][i] = 0;
+	
+					if (obj_ini.role[comp][i] == "Chapter Master") {
+						master = 0;
+						ship_use[argument2]--;
+					}
+					if (obj_ini.role[comp][i] == obj_ini.role[100][2]) then honor--;
+					if (obj_ini.role[comp][i] == "Champion") then champions--;
+	
+					if (obj_ini.role[comp][i] == obj_ini.role[100][5]) then capts--;
+					if (unit.IsSpecialist("chap", true)) then chaplains--;
+					if (unit.IsSpecialist("libs", true)) then psykers--;
+					if (unit.IsSpecialist("apoth", true)) then apothecaries--;
+					if (unit.IsSpecialist("forge", true)) then techmarines--;
+	
+					if (obj_ini.role[comp][i] == "Death Company" && string_count("Dreadnought", obj_ini.armour[comp][i]) == 0) then mahreens--;
+					if (obj_ini.role[comp][i] == obj_ini.role[100][4]) then terminators--;
+					if (((obj_ini.role[comp][i] == obj_ini.role[100][6]) || 
+						(obj_ini.role[comp][i] == "Venerable " + string(obj_ini.role[100][6])) || 
+						string_count("Dreadnought", obj_ini.armour[comp][i]) == 1) && assassinate == false) then dreads--;
+	
+					if (string_count("Bike", obj_ini.mobi[comp][i]) == 0) {
+						if (obj_ini.role[comp][i] == obj_ini.role[100][11]) then mahreens--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][12]) then mahreens--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][8] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][10] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][9]) then mahreens--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][3]) then veterans--;
+					}
+					if (string_count("Bike", obj_ini.mobi[comp][i]) > 0 && vehy == 1) {
+						if (obj_ini.role[comp][i] == obj_ini.role[100][11]) then bikes--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][12]) then bikes--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][8] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][10] || 
+							obj_ini.role[comp][i] == obj_ini.role[100][9]) then bikes--;
+						if (obj_ini.role[comp][i] == obj_ini.role[100][3]) then bikes--;
+					}
+				}
+			}
+		}
 	}
 
 

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -97,7 +97,7 @@ function scr_management(argument0) {
 		}
 	    nam[2]=role_names[Role.HONOUR_GUARD];
 
-	    for (var i = 1; i <= 200; i++) {
+	    for (var i = 0; i <= 200; i++) {
 			unit = fetch_unit([0,i]);
 			if (unit.role() == "Chapter Master") {
 				num[1] += 1;
@@ -382,7 +382,7 @@ function scr_management(argument0) {
 			nam[22] = "Rhino";
 			nam[23] = "Land Speeder";
 			nam[24] = "Whirlwind";
-	        for (var i=1;i<500;i++) {
+	        for (var i=0;i<500;i++) {
 	        	if (obj_ini.name[company][i] == "") then continue;
 	        	unit = fetch_unit([company,i]);
 	            if (unit.role()=role_names[Role.CAPTAIN]){

--- a/scripts/scr_management/scr_management.gml
+++ b/scripts/scr_management/scr_management.gml
@@ -97,7 +97,7 @@ function scr_management(argument0) {
 		}
 	    nam[2]=role_names[Role.HONOUR_GUARD];
 
-	    for (var i = 0; i <= 200; i++) {
+	    for (var i = 0; i <= array_length(obj_ini.name[0]); i++) {
 			unit = fetch_unit([0,i]);
 			if (unit.role() == "Chapter Master") {
 				num[1] += 1;
@@ -382,7 +382,7 @@ function scr_management(argument0) {
 			nam[22] = "Rhino";
 			nam[23] = "Land Speeder";
 			nam[24] = "Whirlwind";
-	        for (var i=0;i<500;i++) {
+	        for (var i=0;i<array_length(obj_ini.name[0]);i++) {
 	        	if (obj_ini.name[company][i] == "") then continue;
 	        	unit = fetch_unit([company,i]);
 	            if (unit.role()=role_names[Role.CAPTAIN]){

--- a/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
+++ b/scripts/scr_player_combat_weapon_stacks/scr_player_combat_weapon_stacks.gml
@@ -98,9 +98,11 @@ function scr_player_combat_weapon_stacks() {
     if (defenses=1) then exit;
 
 
-    var i,g=0;men=0;dreads=0;
-    veh=0
-    for (i=1;i<array_length(att);i++) {
+    var i,g=0;
+    veh=0;
+    men=0;
+    dreads=0;
+    for (i=0;i<array_length(att);i++) {
         // dudes[i]="";
         dudes_num[i]=0;
         // dudes_vehicle[i]=0;
@@ -120,8 +122,8 @@ function scr_player_combat_weapon_stacks() {
             if (marine_casting[g]>=0) then marine_casting[g]=0;
             if (marine_casting[g]<0) then marine_casting[g]+=1;//timer for libs to be able to cast
 
-            if ((marine_id[g]>0) or (ally[g]=true)) and (unit.hp()>0) then marine_dead[g]=0;
-            if ((marine_id[g]>0) or (ally[g]=true)) and (unit.hp()>0) and (marine_dead[g]!=1){
+            if (unit.hp()>0) then marine_dead[g]=0;
+            if (unit.hp()>0 && marine_dead[g]!=true){
                 var head_role = unit.IsSpecialist();
                 var armour_data = unit.get_armour_data();
                 var is_dreadnought = false;
@@ -183,7 +185,7 @@ function scr_player_combat_weapon_stacks() {
                 }
 
                 var j=0,good=0,open=0;// Counts the number and types of marines within this object
-                for (j=1;j<=40;j++){
+                for (j=0;j<=40;j++){
                     if (dudes[j]=="") and (open==0){
                         open=j;// Determine if vehicle here
 
@@ -258,7 +260,7 @@ function scr_player_combat_weapon_stacks() {
                     if (weapon_check!=""){
                         weapon=gear_weapon_data("weapon",weapon_check,"all", false, "standard");
                         if (is_struct(weapon)){
-                            for (j=1;j<=40;j++){
+                            for (j=0;j<=40;j++){
                                 if (wep[j]==""||wep[j]==weapon.name){
                                     add_data_to_stack(j,weapon);
                                     break;

--- a/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
+++ b/scripts/scr_punit_combat_heplers/scr_punit_combat_heplers.gml
@@ -45,10 +45,11 @@ function block_has_armour(target){
 	return target.veh+target.dreads;
 }
 
-function get_leftmost(block_type=obj_pnunit){
+function get_leftmost(block_type=obj_pnunit, include_flanking=true){
 	var left_most = "none";
 	if (instance_exists(block_type)){
 		with (block_type){
+			if (!include_flanking && flank) then continue;
 			if x<=0 then continue;
 			if (men+veh+dreads<=0){
 				x=-5000;


### PR DESCRIPTION
There was a bug with captain's and chapter master names not displaying on the management screen - that I fixed.
There was a bug with captains and chapter master not de-selecting on drop select - that I fixed as well.

There is [this](https://discord.com/channels/714022226810372107/1304818036381057075)
> Deploy marines to ground combat but the captains was never there.I tried unload a captain alone on the enemy planet,next turn the ground combat didn't happen.I also tried unload a entire command squad,captain is still missing in combat.

bug, that I can't fucking fix. I've spent hours trying to find that fucking array that skips CM and Captains that are at index 0.


I can't. I give up.

![image](https://github.com/user-attachments/assets/71642bd7-df89-4292-af0a-c8ed00b7e759)
