### PR TITLE
refactor: scr_ship_occupants

### DIFF
--- a/scripts/scr_fleet_advisor/scr_fleet_advisor.gml
+++ b/scripts/scr_fleet_advisor/scr_fleet_advisor.gml
@@ -210,7 +210,7 @@ function scr_fleet_advisor(){
 
                         cn.temp[118] = $"{obj_ini.ship_carrying[i]}/{obj_ini.ship_capacity[i]}";
                         cn.temp[119] = "";
-                        if (obj_ini.ship_carrying[i] > 0) then cn.temp[119] = scr_ship_occupants(i);
+                        if (obj_ini.ship_carrying[i] > 0) then cn.temp[119] = ship_occupants_list(i);
                     }
                     tooltip_draw($"Carrying ({cn.temp[118]}): {cn.temp[119]}");
                     if (_goto_button.click()) {

--- a/scripts/scr_ship_occupants/scr_ship_occupants.gml
+++ b/scripts/scr_ship_occupants/scr_ship_occupants.gml
@@ -1,67 +1,76 @@
-function scr_ship_occupants(target_ship_id) {
+function ship_occupants_list(target_ship_id) {
+	var carrying_vehicles = [];
+	var carrying_units = [];
+	var total_carrying = [];
+	var carrying_string = "";
 
-	var co,i,oc,ocn,ty,g,good,blur, unit;
-	co=-1;i=-1;ty=0;g=0;good=0;blur="";
-
-	repeat(200){i+=1;oc[i]="";ocn[i]=0;}
-
-	i=0;
-	for (co=0; co<= 10;co++){
-		i=0;
-	    repeat(500){i+=1;
-	        if (obj_ini.role[co][i]!=""){
-	        	unit = fetch_unit([co,i]);
-	        	if (unit.ship_location!=target_ship_id)
-	            good=0;g=0;
-	            repeat(100){g+=1;
-	                if (good=0){
-	                    if (oc[g]==unit.role()){
-	                    	good=1;
-	                    	ocn[g]+=1;
-	                    	break;
-	                    }
-	                }
-	            }
-	            if (good=0){
-	                ty+=1;
-	                oc[ty]=unit.role();
-	                ocn[ty]=1;
-	                good=1;
-	            }
-	        }
-	    }
-	}
-	i=0;co=-1;
-	for (co=0; co<= 10;co++){
-		i=0;
-	    repeat(100){i+=1;
-	        if (obj_ini.veh_role[co][i]!="") and (obj_ini.veh_lid[co][i]=target_ship_id){
-	            good=0;g=0;
-	            repeat(100){g+=1;
-	                if (good=0){
-	                    if (oc[g]=obj_ini.veh_role[co][i]){good=1;ocn[g]+=1;}
-	                }
-	            }
-	            if (good=0){
-	                ty+=1;oc[ty]=obj_ini.veh_role[co][i];ocn[ty]=1;good=1;
-	            }
-	        }
-	    }
+	for (var co = 0; co <= 10; co++) {
+		for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
+			if (obj_ini.role[co][i] != "") {
+				var unit = fetch_unit([co, i]);
+				if (unit.ship_location == target_ship_id) {
+					array_push(carrying_units, unit.role());
+				}
+			}
+		}
 	}
 
-
-
-	i=0;good=1;
-	repeat(100){i+=1;
-	    if (good=1){
-	        if (ocn[i]=1) then blur+=string(ocn[i])+"x "+string(oc[i]);
-	        if (ocn[i]>1) then blur+=string(ocn[i])+"x "+string(oc[i])+"s";
-	        if (ocn[i+1]>0) then blur+=", ";
-	        if (ocn[i+1]=0){blur+=".";good=0;}
-	    }
+	for (var co = 0; co <= 10; co++) {
+		for (var i = 0; i < array_length(obj_ini.veh_role[co]); i++) {
+			if ((obj_ini.veh_role[co][i] != "") && (obj_ini.veh_lid[co][i] == target_ship_id)) {
+				array_push(carrying_vehicles, obj_ini.veh_role[co][i]);
+			}
+		}
 	}
 
-	return(blur);
+	total_carrying = array_concat(carrying_units, carrying_vehicles);
+	total_carrying = count_and_prepend(total_carrying);
 
+	for (var i = 0; i < array_length(total_carrying); i++) {
+		carrying_string += "\n" + total_carrying[i];
+	}
 
+	return carrying_string;
+}
+
+function count_and_prepend(array) {
+    var result_array, unique_items, counts, item_name, count, found;
+    
+    // Arrays to track unique items and their counts
+    unique_items = [];
+    counts = [];
+    
+    // Loop through the input array to count occurrences of each item
+    for (var i = 0; i < array_length(array); i++) {
+        item_name = array[i];
+        found = false;
+        
+        // Check if the item is already in the unique_items array
+        for (var j = 0; j < array_length(unique_items); j++) {
+            if (unique_items[j] == item_name) {
+                counts[j] += 1;
+                found = true;
+                break;
+            }
+        }
+        
+        // If the item was not found, add it to the unique_items array
+        if (!found) {
+            array_push(unique_items, item_name);
+            array_push(counts, 1);
+        }
+    }
+    
+    // Create a result array with the count prepended to the item name
+    result_array = [];
+    for (var i = 0; i < array_length(unique_items); i++) {
+        item_name = unique_items[i];
+        count = counts[i];
+        
+        // Prepend the count and add to the result array
+        array_push(result_array, $"{item_name} x{count}");
+    }
+    
+    // Return the modified array
+    return result_array;
 }

--- a/scripts/scr_ship_occupants/scr_ship_occupants.gml
+++ b/scripts/scr_ship_occupants/scr_ship_occupants.gml
@@ -1,76 +1,84 @@
 function ship_occupants_list(target_ship_id) {
-	var carrying_vehicles = [];
-	var carrying_units = [];
-	var total_carrying = [];
-	var carrying_string = "";
+	try {
+		var carrying_vehicles = [];
+		var carrying_units = [];
+		var total_carrying = [];
+		var carrying_string = "";
 
-	for (var co = 0; co <= 10; co++) {
-		for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
-			if (obj_ini.role[co][i] != "") {
-				var unit = fetch_unit([co, i]);
-				if (unit.ship_location == target_ship_id) {
-					array_push(carrying_units, unit.role());
+		for (var co = 0; co <= 10; co++) {
+			for (var i = 0; i < array_length(obj_ini.role[co]); i++) {
+				if (obj_ini.role[co][i] != "") {
+					var unit = fetch_unit([co, i]);
+					if (unit.ship_location == target_ship_id) {
+						array_push(carrying_units, unit.role());
+					}
 				}
 			}
 		}
-	}
 
-	for (var co = 0; co <= 10; co++) {
-		for (var i = 0; i < array_length(obj_ini.veh_role[co]); i++) {
-			if ((obj_ini.veh_role[co][i] != "") && (obj_ini.veh_lid[co][i] == target_ship_id)) {
-				array_push(carrying_vehicles, obj_ini.veh_role[co][i]);
+		for (var co = 0; co <= 10; co++) {
+			for (var i = 0; i < array_length(obj_ini.veh_role[co]); i++) {
+				if ((obj_ini.veh_role[co][i] != "") && (obj_ini.veh_lid[co][i] == target_ship_id)) {
+					array_push(carrying_vehicles, obj_ini.veh_role[co][i]);
+				}
 			}
 		}
+
+		total_carrying = array_concat(carrying_units, carrying_vehicles);
+		total_carrying = count_and_prepend(total_carrying);
+
+		for (var i = 0; i < array_length(total_carrying); i++) {
+			carrying_string += "\n" + total_carrying[i];
+		}
+
+		return carrying_string;
+	} catch (_exception) {
+		handle_exception(_exception);
 	}
-
-	total_carrying = array_concat(carrying_units, carrying_vehicles);
-	total_carrying = count_and_prepend(total_carrying);
-
-	for (var i = 0; i < array_length(total_carrying); i++) {
-		carrying_string += "\n" + total_carrying[i];
-	}
-
-	return carrying_string;
 }
 
 function count_and_prepend(array) {
-    var result_array, unique_items, counts, item_name, count, found;
-    
-    // Arrays to track unique items and their counts
-    unique_items = [];
-    counts = [];
-    
-    // Loop through the input array to count occurrences of each item
-    for (var i = 0; i < array_length(array); i++) {
-        item_name = array[i];
-        found = false;
-        
-        // Check if the item is already in the unique_items array
-        for (var j = 0; j < array_length(unique_items); j++) {
-            if (unique_items[j] == item_name) {
-                counts[j] += 1;
-                found = true;
-                break;
-            }
-        }
-        
-        // If the item was not found, add it to the unique_items array
-        if (!found) {
-            array_push(unique_items, item_name);
-            array_push(counts, 1);
-        }
-    }
-    
-    // Create a result array with the count prepended to the item name
-    result_array = [];
-    for (var i = 0; i < array_length(unique_items); i++) {
-        item_name = unique_items[i];
-        count = counts[i];
-        
-        // Prepend the count and add to the result array
-        array_push(result_array, $"{item_name} x{count}");
-    }
-    
-    // Return the modified array
-    return result_array;
+	try {
+		var result_array, unique_items, counts, item_name, count, found;
+		
+		// Arrays to track unique items and their counts
+		unique_items = [];
+		counts = [];
+		
+		// Loop through the input array to count occurrences of each item
+		for (var i = 0; i < array_length(array); i++) {
+			item_name = array[i];
+			found = false;
+			
+			// Check if the item is already in the unique_items array
+			for (var j = 0; j < array_length(unique_items); j++) {
+				if (unique_items[j] == item_name) {
+					counts[j] += 1;
+					found = true;
+					break;
+				}
+			}
+			
+			// If the item was not found, add it to the unique_items array
+			if (!found) {
+				array_push(unique_items, item_name);
+				array_push(counts, 1);
+			}
+		}
+		
+		// Create a result array with the count prepended to the item name
+		result_array = [];
+		for (var i = 0; i < array_length(unique_items); i++) {
+			item_name = unique_items[i];
+			count = counts[i];
+			
+			// Prepend the count and add to the result array
+			array_push(result_array, $"{item_name} x{count}");
+		}
+		
+		// Return the modified array
+		return result_array;
+	} catch (_exception) {
+		handle_exception(_exception);
+	}
 }


### PR DESCRIPTION
On the current head this function doesn't work correctly. I assume you can just fiddle with array indices to repair it back, but I took a radical approach.

I have major concerns about performance and garbage leftovers, due to how I refactored this.
I think it's more readable and simple, but the fact that this runs on every frame is absolutely horrible.
Not even the fact that this may inflict performance loss when hovering, but the amount of leftover arrays and shit to be garbage collected is probably insane.

> I noticed 1+ second freezes when garbage collector runs. Not sure if related to this, so has to be cross-tested. But chances are high.
![image](https://github.com/user-attachments/assets/c1d4d4da-cc88-4344-bfd9-0d76661d7523)

*Update1: stuff about GC freezes is fixed in the separate PR, where changes to GC are made. This still doesn't change the fact that this PR generates a lot of leftover arrays, it's just less noticeable.