### PR TITLE
perf: Garbage collector edits

### DIFF
--- a/objects/obj_garbage_collector/Create_0.gml
+++ b/objects/obj_garbage_collector/Create_0.gml
@@ -1,4 +1,4 @@
 gc_timer = 0;
 
 gc_enable(false);
-gc_target_frame_time(100000);
+gc_target_frame_time(100000); // Default is 100; in microseconds;

--- a/objects/obj_garbage_collector/Create_0.gml
+++ b/objects/obj_garbage_collector/Create_0.gml
@@ -1,4 +1,4 @@
 gc_timer = 0;
 
 gc_enable(false);
-gc_target_frame_time(1000000);
+gc_target_frame_time(100000);

--- a/objects/obj_garbage_collector/Step_0.gml
+++ b/objects/obj_garbage_collector/Step_0.gml
@@ -12,7 +12,9 @@ if (gc_timer > 0) {
         var _gc_traversal_t = $"(GC{_gc_stats.gc_frame}) Traversal Time: {_gc_stats.traversal_time} μs";
         var _gc_collection_t = $"(GC{_gc_stats.gc_frame}) Collection Time: {_gc_stats.collection_time} μs";
         var _gc_lines = [_gc_touched, _gc_collected, _gc_traversal_t, _gc_collection_t];
-        show_debug_message_time($"(GC{_gc_stats.gc_frame}) Garbage Collected!");
+        // show_debug_message_time($"(GC{_gc_stats.gc_frame}) Garbage Collected!");
+        debugl("============");
         array_foreach(_gc_lines, debugl);
+        debugl("============");
     });
 }

--- a/objects/obj_garbage_collector/Step_0.gml
+++ b/objects/obj_garbage_collector/Step_0.gml
@@ -2,7 +2,7 @@ if (gc_timer > 0) {
     gc_timer -= 1;
     // show_debug_message($"obj_garbage_collector: gc_timer = {gc_timer}");
 } else {
-    gc_timer = 150;
+    gc_timer = 100; // Default is every frame, so de-facto 1;
     gc_collect();
 
     wait_and_execute(0, function(){

--- a/objects/obj_garbage_collector/Step_0.gml
+++ b/objects/obj_garbage_collector/Step_0.gml
@@ -1,18 +1,18 @@
 if (gc_timer > 0) {
-    gc_timer -= delta_time/1000000;
+    gc_timer -= 1;
     // show_debug_message($"obj_garbage_collector: gc_timer = {gc_timer}");
 } else {
-    gc_timer = 60;
+    gc_timer = 150;
     gc_collect();
 
     wait_and_execute(0, function(){
         var _gc_stats = gc_get_stats();
-        var _gc_touched = $"GC: Objects Touched: {_gc_stats.objects_touched}";
-        var _gc_collected = $"GC: Objects Collected: {_gc_stats.objects_collected}";
-        var _gc_traversal_t = $"GC: Traversal Time: {_gc_stats.traversal_time} μs";
-        var _gc_collection_t = $"GC: Collection Time: {_gc_stats.collection_time} μs";
+        var _gc_touched = $"(GC{_gc_stats.gc_frame}) Objects Touched: {_gc_stats.objects_touched}";
+        var _gc_collected = $"(GC{_gc_stats.gc_frame}) Objects Collected: {_gc_stats.objects_collected}";
+        var _gc_traversal_t = $"(GC{_gc_stats.gc_frame}) Traversal Time: {_gc_stats.traversal_time} μs";
+        var _gc_collection_t = $"(GC{_gc_stats.gc_frame}) Collection Time: {_gc_stats.collection_time} μs";
         var _gc_lines = [_gc_touched, _gc_collected, _gc_traversal_t, _gc_collection_t];
-        show_debug_message_time($"GC: Garbage Collected!");
+        show_debug_message_time($"(GC{_gc_stats.gc_frame}) Garbage Collected!");
         array_foreach(_gc_lines, debugl);
     });
 }


### PR DESCRIPTION
### Done:
* Decrease max collection time by 10 times, to 0.1 second.
* Make it run 20 times more often (60 > 3 seconds).
* Make it run every 100 frames, instead of 60 seconds.
* Add current GC pass number into the message log.

### Todo:
- [x] Probably remove GC debug lines, as they flood the console.
- [x] Probably separate GC lines in the messages with line breaks, to improve visual clarity.