### PR TITLE
refactor: Replace a bunch of global vars with macro

### DIFF
--- a/objects/obj_pnunit/Alarm_5.gml
+++ b/objects/obj_pnunit/Alarm_5.gml
@@ -81,7 +81,8 @@ i=0;
         if (marine_dead[i]=0) and (unit.gene_seed_mutations.mucranoid==1) and (ally[i]=false){
             var muck=floor(random(200))+1;
             if (muck=50){    //slime is armour destroyed due to mucranoid
-                if (array_contains(global.power_armour,unit.armour())){
+                var _power_armour = ARR_power_armour;
+                if (array_contains(_power_armour,unit.armour())){
                     unit.update_armour("", false, false);
                     obj_ncombat.mucra[marine_co[i]]=1;
                     obj_ncombat.slime+=1;

--- a/objects/obj_popup/Create_0.gml
+++ b/objects/obj_popup/Create_0.gml
@@ -334,8 +334,9 @@ calculate_equipment_needs =  function (){
 
         // This checks to see if there is any more in the armoury
         if (req_armour=="Power Armour"){
-            for (i=0;i<array_length(global.power_armour);i++){
-                have_armour_num+=scr_item_count(global.power_armour[i]);
+            var _power_armour = ARR_power_armour;
+            for (i=0;i<array_length(_power_armour);i++){
+                have_armour_num+=scr_item_count(_power_armour[i]);
             }
         }else if (req_armour="Terminator Armour"){
             have_armour_num+=scr_item_count("Terminator Armour");

--- a/scripts/scr_add_artifact/scr_add_artifact.gml
+++ b/scripts/scr_add_artifact/scr_add_artifact.gml
@@ -62,7 +62,8 @@ function scr_add_artifact(artifact_type, artifact_tags, is_identified, artifact_
 
 	if (base_type="Armour") and (base_type_detail=""){
 	    if (rand2<=70){
-	    	base_type_detail=global.power_armour[irandom(array_length(global.power_armour)-1)];
+			var _power_armour = ARR_power_armour;
+	    	base_type_detail=_power_armour[irandom(array_length(_power_armour)-1)];
 	    }
 	    else if (rand2<=80){base_type_detail=choose("Terminator Armour","Tartaros");}
 	    else if (rand2<=90){base_type_detail="Dreadnought Armour";}

--- a/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
+++ b/scripts/scr_draw_unit_image/scr_draw_unit_image.gml
@@ -1253,11 +1253,12 @@ function scr_draw_unit_image(_background=false){
                 surface_reset_target();
                 var bionic_surface = surface_create(512,512);             
                 surface_set_target(bionic_surface);
+                var _body_parts = ARR_body_parts;
 
-                for (var part = 0; part < array_length(global.body_parts); part++) {
-                    if (struct_exists(body[$ global.body_parts[part]], "bionic")) {
+                for (var part = 0; part < array_length(_body_parts); part++) {
+                    if (struct_exists(body[$ _body_parts[part]], "bionic")) {
                         if (armour_type == ArmourType.Normal || unit_armour=="Terminator Armour") {
-                            var body_part = global.body_parts[part];
+                            var body_part = _body_parts[part];
                             var bionic = body[$ body_part][$ "bionic"];
                             switch (body_part) {
                                 case "left_eye":

--- a/scripts/scr_draw_unit_stat_data/scr_draw_unit_stat_data.gml
+++ b/scripts/scr_draw_unit_stat_data/scr_draw_unit_stat_data.gml
@@ -6,6 +6,7 @@ function scr_draw_unit_stat_data(manage=false){
 	var stat_tool_tips = [];
 	var trait_tool_tips = [];
 	var unit_name = name();
+	var _psy_levels = ARR_psy_levels;
 
 	var data_block = {
 		x1: xx + 1008,
@@ -224,7 +225,7 @@ function scr_draw_unit_stat_data(manage=false){
 		array_push(data_lines, data_entry);
 		
 		data_entry = {};
-		data_entry.text = $"Assignment: {global.phy_levels[psionic]} ({psionic})\n";
+		data_entry.text = $"Assignment: {_psy_levels[psionic]} ({psionic})\n";
 		data_entry.tooltip = "The Imperium measures and records the psionic activity and power level of psychic individuals through a rating system called The Assignment. Comprised of a twenty-four point scale, The Assignment simplifies the comparison of psykers to aid Imperial authorities in recognizing possible threats.";
 		array_push(data_lines, data_entry);
 		

--- a/scripts/scr_keyboard_helpers/scr_keyboard_helpers.gml
+++ b/scripts/scr_keyboard_helpers/scr_keyboard_helpers.gml
@@ -1,17 +1,17 @@
 
 
 
-global.virtual_keys = [vk_left, vk_right, vk_up,vk_down,vk_enter,vk_escape,vk_space,vk_shift,vk_control,vk_alt,vk_backspace,vk_tab,vk_home,vk_end,vk_delete,vk_insert,vk_pageup,vk_pagedown,vk_pause,vk_printscreen,
-vk_f1,vk_f2,vk_f3,vk_f4,vk_f5,vk_f6,vk_f7,vk_f8,vk_f9,vk_f10,vk_f11,vk_f12,
-vk_numpad0,vk_numpad1,vk_numpad2,vk_numpad3,vk_numpad4,vk_numpad5,vk_numpad6,vk_numpad7,vk_numpad8,vk_numpad9,
-vk_multiply,vk_divide,vk_add,vk_subtract,vk_decimal];
+#macro ARR_virtual_keys [vk_left, vk_right, vk_up,vk_down,vk_enter,vk_escape,vk_space,vk_shift,vk_control,vk_alt,vk_backspace,vk_tab,vk_home,vk_end,vk_delete,vk_insert,vk_pageup,vk_pagedown,vk_pause,vk_printscreen,vk_f1,vk_f2,vk_f3,vk_f4,vk_f5,vk_f6,vk_f7,vk_f8,vk_f9,vk_f10,vk_f11,vk_f12,vk_numpad0,vk_numpad1,vk_numpad2,vk_numpad3,vk_numpad4,vk_numpad5,vk_numpad6,vk_numpad7,vk_numpad8,vk_numpad9, vk_multiply,vk_divide,vk_add,vk_subtract,vk_decimal]
+
 //,vk_lshift,vk_lcontrol,vk_lalt,vk_rshift,vk_rcontrol,vk_ralt these ones can cause issues
+
 
 function press_exclusive(press_choice){
 	if (keyboard_check_pressed(vk_nokey)) then return false;
 	if (!keyboard_check_pressed(press_choice)) then return false;
-	for (var i=0;i<array_length(global.virtual_keys);i++){
-		if (keyboard_check(global.virtual_keys[i]) && global.virtual_keys[i] != press_choice){
+	var _virtual_keys = ARR_virtual_keys;
+	for (var i=0;i<array_length(_virtual_keys);i++){
+		if (keyboard_check(_virtual_keys[i]) && _virtual_keys[i] != press_choice){
 			return false;
 		}
 	}
@@ -22,8 +22,9 @@ function press_exclusive(press_choice){
 function hold_exclusive(press_choice){
 	if (keyboard_check(vk_nokey)) then return false;
 	if (!keyboard_check(press_choice)) then return false;
-	for (var i=0;i<array_length(global.virtual_keys);i++){
-		if (keyboard_check(global.virtual_keys[i]) && global.virtual_keys[i] != press_choice){
+	var _virtual_keys = ARR_virtual_keys;
+	for (var i=0;i<array_length(_virtual_keys);i++){
+		if (keyboard_check(_virtual_keys[i]) && _virtual_keys[i] != press_choice){
 			return false;
 		}
 	}
@@ -36,8 +37,9 @@ function press_with_held(press_choice, hold_choice){
 	if (keyboard_check_pressed(vk_nokey)) then return false;
 	if (!keyboard_check_pressed(press_choice) || !keyboard_check(hold_choice)) then return false;
 	var cur_vert_key;
-	for (var i=0;i<array_length(global.virtual_keys);i++){
-		cur_vert_key =  global.virtual_keys[i];
+	var _virtual_keys = ARR_virtual_keys;
+	for (var i=0;i<array_length(_virtual_keys);i++){
+		cur_vert_key =  _virtual_keys[i];
 		if (cur_vert_key==press_choice || cur_vert_key==hold_choice) then continue;
 		if (keyboard_check(cur_vert_key)){
 			show_debug_message($"non viable click {keyboard_check_pressed(press_choice)},{keyboard_check(hold_choice)}");

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -17,7 +17,7 @@
 		the first int is a base or mean value the second int is a sd number to be passed to the gauss() function
 		the string (usually max) is guidance so in the instance of max it will pick the larger value of the mean and the gauss function return
 */
-global.stat_list = ["constitution", "strength", "luck", "dexterity", "wisdom", "piety", "charisma", "technology","intelligence", "weapon_skill", "ballistic_skill"];
+#macro ARR_stat_list ["constitution", "strength", "luck", "dexterity", "wisdom", "piety", "charisma", "technology","intelligence", "weapon_skill", "ballistic_skill"]
 
 global.stat_shorts = {
 	"constitution":"CON", 
@@ -34,14 +34,14 @@ global.stat_shorts = {
 }
 
 // will swap these out for enums or some better method as i develop where this is going
-global.body_parts = ["left_leg", "right_leg", "torso", "right_arm", "left_arm", "left_eye", "right_eye", "throat", "jaw","head"];
-global.body_parts_display = ["Left Leg", "Right Leg", "Torso", "Right Arm", "Left Arm", "Left Eye", "Right Eye", "Throat", "Jaw","Head"];
+#macro ARR_body_parts ["left_leg", "right_leg", "torso", "right_arm", "left_arm", "left_eye", "right_eye", "throat", "jaw","head"]
+#macro ARR_body_parts_display ["Left Leg", "Right Leg", "Torso", "Right Arm", "Left Arm", "Left Eye", "Right Eye", "Throat", "Jaw","Head"]
 global.religions={
 	"imperial_cult":{"name":"Imperial Cult"},
 	"cult_mechanicus":{"name":"Cult Mechanicus"}, 
 	"eight_fold_path":{"name":"The Eight Fold Path"}
 };
-global.power_armour=["MK7 Aquila","MK6 Corvus","MK5 Heresy","MK3 Iron Armour","MK4 Maximus","Power Armour"];
+#macro ARR_power_armour ["MK7 Aquila","MK6 Corvus","MK5 Heresy","MK3 Iron Armour","MK4 Maximus","Power Armour"]
 enum location_types {
 	planet,
 	ship,
@@ -50,7 +50,7 @@ enum location_types {
 	warp
 }
 
-global.phy_levels =["Rho","Pi","Omicron","Xi","Nu","Mu","Lambda","Kappa","Iota","Theta","Eta","Zeta","Epsilon","Delta","Gamma","Beta","Alpha","Alpha Plus","Beta","Gamma Plus"]
+#macro ARR_psy_levels ["Rho","Pi","Omicron","Xi","Nu","Mu","Lambda","Kappa","Iota","Theta","Eta","Zeta","Epsilon","Delta","Gamma","Beta","Alpha","Alpha Plus","Beta","Gamma Plus"]
 global.trait_list = {
 	"champion":{
 		weapon_skill : [10,5,"max"],      
@@ -928,7 +928,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 	allegiance =faction;	//faction alligience defaults to the chapter
 	
 	static stat_boosts = function(stat_boosters){
-		stats = global.stat_list;
+		var stats = ARR_stat_list;
 		var edits = struct_get_names(stat_boosters);
 		var edit_stat,random_stat,stat_mod;		
 		for (var stat_iter =0; stat_iter <array_length(stats);stat_iter++){
@@ -1059,12 +1059,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 		} else {
 			var item_key_map = {};
 			var body_part_area_keys
-			for (var i=0;i<array_length(global.body_parts);i++){//search all body parts
-				body_area = body[$ global.body_parts[i]]
+			var _body_parts = ARR_body_parts;
+			for (var i=0;i<array_length(_body_parts);i++){//search all body parts
+				body_area = body[$ _body_parts[i]]
 				body_part_area_keys=struct_get_names(body_area);
 				for (var b=0;b<array_length(body_part_area_keys);b++){
 					if (body_part_area_keys[b]==body_item_key){
-						item_key_map[$ global.body_parts[i]] = body_area[$ body_item_key]
+						item_key_map[$ _body_parts[i]] = body_area[$ body_item_key]
 					}
 				}
 				
@@ -1496,8 +1497,9 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				add_or_sub_health(30);
 			}
 			var bionic_possible = [];
-			for (var body_part = 0; body_part < array_length(global.body_parts);body_part++){
-				part = global.body_parts[body_part];
+			var _body_parts = ARR_body_parts;
+			for (var body_part = 0; body_part < array_length(_body_parts);body_part++){
+				part = _body_parts[body_part];
 				if (!get_body_data("bionic",part)){
 					array_push(bionic_possible, part);
 				}

--- a/scripts/scr_pen_And_paper/scr_pen_And_paper.gml
+++ b/scripts/scr_pen_And_paper/scr_pen_And_paper.gml
@@ -90,7 +90,7 @@ function PenAndPaperSim() constructor{
 global.character_tester = new PenAndPaperSim();
 
 function compare_stats(stat_one, stat_two){
-	var _stat_names = global.stat_list;
+	var _stat_names = ARR_stat_list;
 	var stat_diff = {};
 	for (var i=0;i<array_length(_stat_names);i++){
 		stat_diff[$_stat_names[i]] = stat_one[$_stat_names[i]] - stat_two[$_stat_names[i]]
@@ -100,7 +100,7 @@ function compare_stats(stat_one, stat_two){
 
 function print_stat_diffs(diffs){
 	var _diff_string = "";
-	var _stat_names = global.stat_list;
+	var _stat_names = ARR_stat_list;
 	var _stat_short = global.stat_shorts;
 	for (var i=0;i<array_length(_stat_names);i++){
 		if (diffs[$_stat_names[i]] != 0 ){

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -348,9 +348,11 @@ function scr_ui_manage() {
         	x2 = x1+string_width(var_text);
         	y2 = y1+string_height(var_text);
 	        draw_text_outline(x1,y1,var_text);
-	        for (var part = 0; part<array_length(global.body_parts);part++){
-				if (struct_exists(selected_unit.body[$ global.body_parts[part]], "bionic")){
-					var part_display = global.body_parts_display[part];
+			var _body_parts = ARR_body_parts;
+			var _body_parts_display = ARR_body_parts_display;
+	        for (var part = 0; part<array_length(_body_parts);part++){
+				if (struct_exists(selected_unit.body[$ _body_parts[part]], "bionic")){
+					var part_display = _body_parts_display[part];
 					bionic_tooltip += $"Bionic {part_display}";
 					switch (part_display) {
 						case "Left Leg":

--- a/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
+++ b/scripts/scr_unit_detail_text/scr_unit_detail_text.gml
@@ -8,6 +8,9 @@ function scr_unit_detail_text(){
 	var unit_role = role();
 	var body_augmentations = {mutations:[], bionics:[[],[]]}
 	var body_bionics = get_body_data("bionic");
+	var _phy_levels = ARR_psy_levels;
+	var _body_parts = ARR_body_parts;
+	var _body_parts_display = ARR_body_parts_display;
 	if(base_group == "astartes"){
 		is_astartes = true;
 	}
@@ -62,7 +65,7 @@ function scr_unit_detail_text(){
 		}
 
 		// Psyker text
-		unit_data_string += $"Has an Assignment rating of {global.phy_levels[psionic]} ({psionic}) ";
+		unit_data_string += $"Has an Assignment rating of {_phy_levels[psionic]} ({psionic}) ";
 		var is_lib = array_contains(["Lexicanum", "Codiciery",obj_ini.role[100,17]], role());
 		if (psionic<2){
 			unit_data_string += "and as such has almost no presence in the warp.";
@@ -116,9 +119,9 @@ function scr_unit_detail_text(){
 			if (bionic_count == 0){
 				unit_data_string+= "Has no bodily augmentations besides his astartes gene-seed and organs.";
 			}else if(bionic_count == 1 && array_length(bionic_positions)>0){
-				for (var i=0;i<array_length(global.body_parts);i++){
-					if (bionic_positions[0]==global.body_parts[i]){
-						unit_data_string+= $"Has a bionic {global.body_parts_display[i]}.";
+				for (var i=0;i<array_length(_body_parts);i++){
+					if (bionic_positions[0]==_body_parts[i]){
+						unit_data_string+= $"Has a bionic {_body_parts_display[i]}.";
 					}
 				}
 			}else if((bionic_count >1) and (bionic_count <=4)){

--- a/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
+++ b/scripts/scr_unit_equip_functions/scr_unit_equip_functions.gml
@@ -28,7 +28,7 @@ function scr_update_unit_armour(new_armour, from_armoury=true, to_armoury=true, 
 	  	if (_new_power_armour){
 	  		require_carpace=true;
 	  		if (new_armour=="Power Armour"){
-	  			armour_list = global.power_armour;
+	  			armour_list = ARR_power_armour;
 	  		}
 	  	} else if (new_armour="Terminator Armour"){
 	  		require_carpace=true;


### PR DESCRIPTION
I'm not 100% why, but you can't reference a macro directly, i.e. `array_length(macro)` fails on build. Because of that, I had to assign macro into local vars beforehand.

I just want to generally note: globals that are used as constants are a bad practice. Very bad.
![image](https://github.com/user-attachments/assets/820ccf97-52ba-47d9-9d8a-cc76e5d654e6)

### Todo:

- [x] ~~I want to see if it's possible to replace global static structs with something. Macro can't hold structs, so it should be something else.~~ You can use a function, that'll return a struct, but this is no better in terms of reference overhead and additionally creates struct to be garbage collected on every call. So, no, there is no better way, I don' think.
- [x] ~~Figure out if using static variables is actually worse for performance than locals.~~ They are.  Unless you want a variable to preform like a persistent instance variable of a function, that you can modify and reference throughout your code, kinda like a global var, you shouldn't use static vars. They take up memory and are never freed, the same way as globals. 
Honestly, I'm not even sure how are they different from globals. Maybe only in how you reference them, with `function_name.static_name`.