### PR TITLE
fix: `mission_star` showing up in popup text

### DIFF
--- a/objects/obj_popup/Step_0.gml
+++ b/objects/obj_popup/Step_0.gml
@@ -755,7 +755,7 @@ if (title="Necron Tunnels : 3"){option1="Continue";option2="Return to the surfac
 if (title="He Built It") and (option1="") and (string_count("submerged",text)=0){
     option1="Execute the heretic";
     option2="Move him to the Penitorium";
-    option3="mission_star see no problem";
+    option3="I see no problem";
 }
 
 


### PR DESCRIPTION
I didn't see any other cases where the option text was using `mission_star` or something like that but can add those in if there are some