### PR TITLE
feat: Chapter selection multirow grid & dbg overlay

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -1409,6 +1409,6 @@
   ],
   "templateType": null,
   "TextureGroups": [
-    {"resourceType":"GMTextureGroup","resourceVersion":"1.3","name":"Default","autocrop":true,"border":2,"compressFormat":"bz2","directory":"","groupParent":null,"isScaled":false,"loadType":"default","mipsToGenerate":0,"targets":-1,},
+    {"resourceType":"GMTextureGroup","resourceVersion":"1.3","name":"Default","autocrop":true,"border":2,"compressFormat":"bz2","customOptions":"","directory":"","groupParent":null,"isScaled":false,"loadType":"default","mipsToGenerate":0,"targets":-1,},
   ],
 }

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -2,7 +2,6 @@
  * * obj_creation is used as part of the main menu new game and chapter creation logic
  * It contains data and logic for setting up custom chapters as well as populating the new game menu with data for pre-existing chapters.
  */
-// show_debug_overlay(true);
 keyboard_string="";
 
 #region Global Settings: volume, fullscreen etc
@@ -15,6 +14,62 @@ settings_heresy=ini_read_real("Settings","settings_heresy",0);
 settings_fullscreen=ini_read_real("Settings","fullscreen",1);
 settings_window_data=ini_read_string("Settings","window_data","fullscreen");
 ini_close();
+#endregion
+
+#region Icon Grid settings for chapter selection
+icon_width = 48;
+icon_height = 48;
+/// distance between 2 rows of icons in the grid
+icon_row_gap = 60;
+/// distance between section heading and icon grid row
+icon_gap_y = 34;
+/// distance between columns in icon grid
+icon_gap_x = 53;
+/// x coord of left edge of the icon grid
+icon_grid_left_edge = 441;
+/// Max number of columns of icons until a new row is made
+max_cols = 10;
+/// x coord of the right edge of the icon grid
+icon_grid_right_edge = function() {return icon_grid_left_edge + (icon_gap_x * max_cols -1)}; // icon_gap_x * max number of desired columns - 1
+/// y coord of Founding section heading
+founding_y = 133;
+/// y coord of Successor section heading
+successor_y = 250;
+/// y coord of Custom section heading
+custom_y = 463;
+/// y coord of Other section heading
+other_y = 593;
+
+var show_debug = false;
+if(show_debug){
+    show_debug_overlay(true);
+    dbg_view("obj_creation_dbg", true);
+    dbg_section("Icon Grid");
+    ref_to_max_cols = ref_create(self, "max_cols");
+    ref_to_icon_width = ref_create(self, "icon_width");
+    ref_to_icon_height = ref_create(self, "icon_height");
+    ref_to_icon_grid_left_edge = ref_create(self, "icon_grid_left_edge");
+    ref_to_icon_gap_y = ref_create(self, "icon_gap_y");
+    ref_to_icon_gap_x = ref_create(self, "icon_gap_x");
+    ref_to_icon_row_gap = ref_create(self, "icon_row_gap");
+    dbg_slider_int(ref_to_max_cols,1,15);
+    dbg_slider_int(ref_to_icon_width,1,100);
+    dbg_slider_int(ref_to_icon_height,1,100);
+    dbg_slider_int(ref_to_icon_grid_left_edge,1,1000);
+    dbg_slider_int(ref_to_icon_gap_y,1,300);
+    dbg_slider_int(ref_to_icon_gap_x,1,300);
+    dbg_slider_int(ref_to_icon_row_gap,1,300);
+
+    dbg_section("Heading Positions")
+    ref_to_founding_y = ref_create(self, "founding_y");
+    ref_to_successor_y = ref_create(self, "successor_y");
+    ref_to_custom_y = ref_create(self, "custom_y");
+    ref_to_other_y = ref_create(self, "other_y");
+    dbg_slider_int(ref_to_founding_y,1,1000);
+    dbg_slider_int(ref_to_successor_y,1,1000);
+    dbg_slider_int(ref_to_custom_y,1,1000);
+    dbg_slider_int(ref_to_other_y,1,1000);
+}
 #endregion
 
 window_data=string(window_get_x())+"|"+string(window_get_y())+"|"+string(window_get_width())+"|"+string(window_get_height())+"|";
@@ -80,6 +135,7 @@ goto_slide=1;
 highlight=0;
 highlighting=0;
 old_highlight=0;
+/// 1 = select chap, 2 = name, strength, adv/disadv, 3 = homeworld, discipline, 4 = livery, 5 = mutations, disposition, 6 = chapter master
 slide=1;
 slide_show=1;
 cooldown=0;

--- a/objects/obj_creation/Draw_0.gml
+++ b/objects/obj_creation/Draw_0.gml
@@ -154,7 +154,7 @@ if (slate4>0){
                 // Highlight on hover
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
                 //Click
-                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
+                if (grid.clicked()){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -195,14 +195,14 @@ if (slate4>0){
             }
             
             // Hover
-            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
+            if (grid.hover() && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=chap.id;tool=1;}
                 // Highlight white on hover
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
 
                 //Click
-                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
+                if (grid.clicked()){
 					if(chap.loaded == true && chap.disabled == false){
                         if(chap.icon > global.normal_icons_count){
                             global.chapter_icon_sprite = spr_icon_chapters;
@@ -245,13 +245,13 @@ if (slate4>0){
             scr_image("creation/chapters/icons",chap.icon,grid.x1, grid.y1, grid.w, grid.h);
 
             // Hover
-            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
+            if (grid.hover() && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
                 // Highlight white on hover
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
                 //Click
-                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
+                if (grid.clicked()){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -282,11 +282,11 @@ if (slate4>0){
             draw_sprite_stretched(spr_icon_chapters,i-1001,grid.x1, grid.y1, grid.w, grid.h);
 
             
-            if (grid.hover() && slate4>=30)){
+            if (grid.hover() && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
-                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
+                if (grid.clicked()){
                     cooldown=8000;
                     icon=1;
                     icon_name="da";

--- a/objects/obj_creation/Draw_0.gml
+++ b/objects/obj_creation/Draw_0.gml
@@ -84,6 +84,12 @@ if (slate4>0){
                 x2 = x1 + w;
                 y2 = y1 + h;
             },
+            hover : function(){
+                 return scr_hit(x1,y1,x2,y2);
+            },
+            clicked : function(){
+                 return point_and_click([x1,y1,x2,y2]);
+            }
         };
 
 
@@ -101,13 +107,13 @@ if (slate4>0){
             scr_image("creation/chapters/icons", chap.icon, grid.x1,grid.y1,grid.w,grid.h);
 
             // Hover
-            if(scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
+            if(grid.hover() && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
                 // Highlight white on hover
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
                 // Click
-                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
+                if (grid.clicked()){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -142,7 +148,7 @@ if (slate4>0){
             scr_image("creation/chapters/icons",chap.icon,grid.x1,grid.y1,grid.w, grid.h);
 
             // Hover
-            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
+            if (grid.hover() && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
                 // Highlight on hover
@@ -276,7 +282,7 @@ if (slate4>0){
             draw_sprite_stretched(spr_icon_chapters,i-1001,grid.x1, grid.y1, grid.w, grid.h);
 
             
-            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && (slate4>=30)){
+            if (grid.hover() && slate4>=30)){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
                 draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);

--- a/objects/obj_creation/Draw_0.gml
+++ b/objects/obj_creation/Draw_0.gml
@@ -31,7 +31,8 @@ allow_colour_click = (cooldown<=0)   and (mouse_left>=1) and (custom>1) and (!in
 
 draw_set_alpha(slate4/30);
 if (slate4>0){
-    if (slide=1){
+    /* Chapter Selection grid */
+    if (slide==1){
         draw_set_color(38144);
         draw_set_font(fnt_40k_30b);
         draw_set_halign(fa_center);
@@ -39,39 +40,74 @@ if (slate4>0){
         
         draw_set_font(fnt_40k_30b);
         draw_set_halign(fa_left);
-        icon_gap_y = 34;
-        icon_gap_x = 53;
-        founding_y = 133;
-        successor_y = 250;
-        custom_y = 463;
-        other_y = 593
 
         draw_text_transformed(440,founding_y,"Founding Chapters",0.75,0.75,0);
         draw_text_transformed(440,successor_y,"Existing Chapters",0.75,0.75,0);
 		draw_text_transformed(440,custom_y,string_hash_to_newline("Custom Chapters"),0.75,0.75,0);
         draw_text_transformed(440,other_y,string_hash_to_newline("Other"),0.75,0.75,0);
 
+        /// @localvar grid object to keep track of where to draw icon boxes
+        var grid = {
+            count: 0,
+            x1: icon_grid_left_edge,
+            y1: founding_y + icon_gap_y,
+            w: icon_width,
+            h: icon_height,
+            x2:0,
+            y2:0,
+            left_edge: icon_grid_left_edge,
+            right_edge: icon_grid_right_edge(),
+            row_gap: icon_row_gap,
+            section_gap: icon_gap_y,
+            col_gap: icon_gap_x,
+            /// Updates coords to draw a new icon, creating new rows where needed
+            new_cell: function() {
+                if(count > 0){
+                    x1 = x1 + col_gap;
+                } else {
+                    x2 = x1 + w;
+                    y2 = y1 + h;
+                }
+                if(x1 > right_edge){
+                    x1 = left_edge;
+                    y1 = y1 + row_gap;
+                }
+                x2 = x1 + w;
+                y2 = y1 + h;
+                count += 1;
+            },
+            /// given a new y coord for a section heading resets cell drawing to start a new grid
+            new_section: function(new_y){
+                count = 0;
+                x1 = left_edge;
+                y1 = new_y + section_gap;
+                x2 = x1 + w;
+                y2 = y1 + h;
+            },
+        };
 
-        
+
 
         /** * Founding Chapters */
-        var x2,y2,i,new_hover,tool;
-        x2=441;y2=founding_y + icon_gap_y;i=1;new_hover=highlight;tool=0;
+        var i,new_hover,tool;
+        i=1;new_hover=highlight;tool=0;
         for(var c = 0; c < array_length(founding_chapters); c++){
             var chap = founding_chapters[c]
             i = chap.id;
+
+            grid.new_cell();
             
-            draw_sprite(spr_creation_icon,0,x2,167);
-            scr_image("creation/chapters/icons", chap.icon,x2,y2,48,48);
-            // draw_sprite_stretched(spr_icon,i,x2,167,48,48);
-            if(scr_hit(x2,y2, x2+48, y2+48) && slate4>=30){
-            // if (mouse_x>=x2) and (mouse_y>=y2) and (mouse_x<x2+48) and (mouse_y<y2+48) and (slate4>=30){
+            draw_sprite(spr_creation_icon,0,grid.x1,grid.y1);
+            scr_image("creation/chapters/icons", chap.icon, grid.x1,grid.y1,grid.w,grid.h);
+
+            // Hover
+            if(scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
-                draw_set_alpha(0.1);draw_set_color(c_white);
-                draw_rectangle(x2,y2,x2+48,y2+48,0);
-                draw_set_alpha(slate4/30);
-                if (point_and_click([x2,y2,x2+48,y2+48])){
+                // Highlight white on hover
+                draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
+                // Click
+                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -89,28 +125,30 @@ if (slate4>0){
                     }
                 }
             }
-            x2+=icon_gap_x;
+            // grid.x1 += icon_gap_x;
         }
         
         /** * Successor Chapters */
-        x2=441;y2=successor_y + icon_gap_y;new_hover=highlight;
+        grid.new_section(successor_y);
+
+        new_hover=highlight;
         for(var c = 0; c < array_length(successor_chapters); c++){
             var chap = successor_chapters[c]
             i = chap.id;
-                    
-            draw_sprite(spr_creation_icon,0,x2,y2);
-            // draw_sprite_stretched(spr_icon,i,x2,397,48,48);
-            scr_image("creation/chapters/icons",chap.icon,x2,y2,48,48);
 
-            
-            if (scr_hit(x2, y2, x2+48, y2+48) && slate4>=30){
+            grid.new_cell();
+
+            draw_sprite(spr_creation_icon,0,grid.x1,grid.y1);
+            scr_image("creation/chapters/icons",chap.icon,grid.x1,grid.y1,grid.w, grid.h);
+
+            // Hover
+            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
-                draw_set_alpha(0.1);draw_set_color(c_white);
-                draw_rectangle(x2,y2,x2+48,y2+48,0);
-                draw_set_alpha(slate4/30);
+                // Highlight on hover
+                draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
                 //Click
-                if (point_and_click([x2, y2, x2+48, y2+48])){
+                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -127,36 +165,38 @@ if (slate4>0){
                     }
                 }
             }
-            x2+=icon_gap_x;
         }
         
         /** * Saved Custom Chapters */
-		x2=441;y2=custom_y + icon_gap_y;new_hover=highlight;
+        grid.new_section(custom_y);
+		new_hover=highlight;
         for(var c = 0; c < array_length(custom_chapters); c++){
             var chap = custom_chapters[c];
             i = chap.id;
             
+            grid.new_cell();
             
-            draw_sprite(spr_creation_icon,0,x2,y2);
+            draw_sprite(spr_creation_icon,0,grid.x1,grid.y1);
             if(chap.loaded == false){
                 // should be the icon that says 'custom'
-                draw_sprite_stretched(spr_icon_chapters, 31, x2,y2,48,48); 
+                draw_sprite_stretched(spr_icon_chapters, 31, grid.x1,grid.y1, grid.w, grid.h); 
             } else {
                 if(chap.icon > global.normal_icons_count){
-                    draw_sprite_stretched(spr_icon_chapters, chap.icon - global.normal_icons_count, x2,y2,48,48);
+                    draw_sprite_stretched(spr_icon_chapters, chap.icon - global.normal_icons_count, grid.x1,grid.y1, grid.w, grid.h);
                 } else {
-                    scr_image("creation/chapters/icons", chap.icon, x2,y2,48,48);
+                    scr_image("creation/chapters/icons", chap.icon, grid.x1,grid.y1, grid.w, grid.h);
                 }
             }
             
-            
-            if (scr_hit(x2, y2, x2+48, y2+48) && slate4>=30){
+            // Hover
+            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=chap.id;tool=1;}
-                draw_set_alpha(0.1);draw_set_color(c_white);
-                draw_rectangle(x2,y2,x2+48,y2+48,0);
-                draw_set_alpha(slate4/30);
-                if (point_and_click([x2, y2, x2+48, y2+48])){
+                // Highlight white on hover
+                draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
+
+                //Click
+                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
 					if(chap.loaded == true && chap.disabled == false){
                         if(chap.icon > global.normal_icons_count){
                             global.chapter_icon_sprite = spr_icon_chapters;
@@ -183,28 +223,29 @@ if (slate4>0){
                     }
                 }
             }
-            x2+=icon_gap_x;
         }
 
         /** * Other Chapters */
-        x2=441;y2=other_y + icon_gap_y;new_hover=highlight;
+        grid.new_section(other_y);
+
+        new_hover=highlight;
         for(var c = 0; c < array_length(other_chapters); c++){
             var chap = other_chapters[c];
             i = chap.id;
-        
-            draw_sprite(spr_creation_icon,0,x2,y2);
-            // draw_sprite_stretched(spr_icon,i,x2,y2,48,48);
-            scr_image("creation/chapters/icons",chap.icon,x2,y2,48,48);
 
-            
-            if (scr_hit(x2, y2, x2+48, y2+48) && slate4>=30){
+            grid.new_cell();        
+            draw_sprite(spr_creation_icon,0,grid.x1, grid.y1);
+            // draw_sprite_stretched(spr_icon,i,x2,y2,48,48);
+            scr_image("creation/chapters/icons",chap.icon,grid.x1, grid.y1, grid.w, grid.h);
+
+            // Hover
+            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && slate4>=30){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
-                draw_set_alpha(0.1);draw_set_color(c_white);
-                draw_rectangle(x2,y2,x2+48,y2+48,0);
-                draw_set_alpha(slate4/30);
+                // Highlight white on hover
+                draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
                 //Click
-                if (point_and_click([x2, y2, x2+48, y2+48])){
+                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
                     cooldown=8000;
                     chapter_name=chap.name;
                     if (!chap.disabled){
@@ -222,23 +263,24 @@ if (slate4>0){
                     }
                 }
             }
-            x2+=icon_gap_x;
         }
         
-        /* Custom + Random*/
-        x2+=53;
+        /* Blank Custom + Random*/
+        grid.new_cell();
+
         i=1001;
         repeat(2){
-            draw_sprite(spr_creation_icon,0,x2,y2);
-            draw_sprite_stretched(spr_icon_chapters,i-1001,x2,y2,48,48);
+            grid.new_cell();            
+
+            draw_sprite(spr_creation_icon,0,grid.x1, grid.y1);
+            draw_sprite_stretched(spr_icon_chapters,i-1001,grid.x1, grid.y1, grid.w, grid.h);
+
             
-            if (scr_hit(x2, y2, x2+48, y2+48) && (slate4>=30)){
+            if (scr_hit(grid.x1, grid.y1, grid.x2, grid.y2) && (slate4>=30)){
                 if (old_highlight!=highlight) and (highlight!=i) and (goto_slide!=2){old_highlight=highlight;highlighting=1;}
                 if (goto_slide!=2){highlight=i;tool=1;}
-                draw_set_alpha(0.1);draw_set_color(c_white);
-                draw_rectangle(x2,y2,x2+48,y2+48,0);
-                draw_set_alpha(slate4/30);
-                if (point_and_click([x2, y2, x2+48, y2+48])){
+                draw_rectangle_color_simple(grid.x1, grid.y1, grid.x2, grid.y2,0,c_white,0.1);
+                if (point_and_click([grid.x1, grid.y1, grid.x2, grid.y2])){
                     cooldown=8000;
                     icon=1;
                     icon_name="da";
@@ -248,7 +290,7 @@ if (slate4>0){
                     if (i=1002){custom=1;scr_chapter_random(1);}
                 }
             }
-            i+=1;x2+=53;
+            i+=1;
         }
         
         if (tool=1) and (highlighting<30) then highlighting+=1;

--- a/scripts/scr_chapter_random/scr_chapter_random.gml
+++ b/scripts/scr_chapter_random/scr_chapter_random.gml
@@ -1,4 +1,7 @@
 /// @mixin obj_creation
+/// @description  Called when an empty custom chapter icon is picked, or the custom icon in bottom right is picked from the new game menu.
+/// if "Create Custom" is picked, argument0 = 0, if "Create Random" is picked, argument0 = 1
+/// @param {Real} argument0 0 if Blank Custom, 1 if Random
 function scr_chapter_random(argument0) {
 
 	// argument0 = 0 = create custom 


### PR DESCRIPTION
This doesn't look like it does anything when you load the game right now but it will enable a future state where we have enough chapters built into the game that we would want the grid of icons to automatically add rows for each section instead of going off the side of the screen. 

It also has some code showing off the debug overlay and interactive variables, set `var show_debug = true` on line 43 of `obj_creation/Create_0.gml` to see how it works. This feature could be useful in other areas that are tricky to debug, but it does require some amount of setup which might make it difficult to drag and drop to new parts of the codebase. 