### PR TITLE
feat: Disable borderless window

### DIFF
--- a/options/windows/options_windows.yy
+++ b/options/windows/options_windows.yy
@@ -3,7 +3,7 @@
   "resourceVersion": "1.1",
   "name": "Windows",
   "option_windows_allow_fullscreen_switching": true,
-  "option_windows_borderless": true,
+  "option_windows_borderless": false,
   "option_windows_company_info": "",
   "option_windows_copy_exe_to_dest": false,
   "option_windows_copyright_info": "",


### PR DESCRIPTION
Borderless windowed mode offers no benefits and only downsides: 
- You can't change the window location 
- Auto center is buggy 
- Can't resize window 

All of these problems go away with bordered windowed mode. 
Unfortunately, this is a compiler setting, and doesn't look like it can be changed dynamically in-game with a setting, but tbh i don't see much reason to not make this change.