### PR TITLE
feat: New weapon tags for custom stat scaling

### DIFF
--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2027,7 +2027,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 
 			if IsSpecialist("libs") or has_trait("warp_touched"){
 				if (primary_weapon.has_tag("force")){
-					var force_modifier = (psionic * 2) * (intelligence/50);
+					var force_modifier = (psionic * 3) * (intelligence/40);
 					_melee_mod += force_modifier / 100;
 					explanation_string += $"  PSYxINT (Force): {_format_sign(force_modifier)}%#";
 				}		
@@ -2083,7 +2083,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				var side_arm = floor(secondary_modifier*((_melee_mod/100)*secondary_weapon.attack));
 				if (side_arm>0){
 					final_attack+=side_arm;
-					explanation_string+=$"Side Arm: +{side_arm}({side_arm_data})#";
+					explanation_string+=$"Side Arm: +{side_arm} ({side_arm_data})#";
 				}
 			}
 

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1994,6 +1994,16 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					basic_wep_string += $"Active Force Weapon: x{force_modifier}#  Base: 0.10#  WSxPSIxINT: x{(weapon_skill/100)*(psionic/10)*(intelligence/10)}#  EXP: x{experience/1000}#";
 				}		
 			};
+			if (primary_weapon.has_tag("martial") ||_wep2.has_tag("martial")){
+				var martial_modifier = (((dexterity/40)) + (experience/1000)+0.1);
+				primary_weapon.attack *= martial_modifier;
+				basic_wep_string += $"Martial Prowess: x{martial_modifier}#  Base: 0.10#  DEX: {(dexterity/40)}#  EXP: {experience/1000}#";
+			};
+			if (primary_weapon.has_tag("savage") ||_wep2.has_tag("savage")){
+				var savage_modifier = (((strength/40)) + (experience/1000)+0.1);
+				primary_weapon.attack *= savage_modifier;
+				basic_wep_string += $"Innate Savagery: x{savage_modifier}#  Base: 0.10#  STR: {(strength/40)}#  EXP: {experience/1000}#";
+			};
 			explanation_string = basic_wep_string + explanation_string
 
 			if (melee_carrying[0]>melee_carrying[1]){

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -1923,16 +1923,19 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				carry_string+=$"{mobility_item()}: {format_number_with_sign(mobility_carry)}#";
 			}						
 			return [melee_carrying,melee_hands_limit,carry_string]						
-		}		
-		static melee_attack = function(weapon_slot=0){
-			encumbered_melee=false;
-			melee_att = 100*(((weapon_skill/100) * (strength/20)) + (experience/1000)+0.1);
-			var explanation_string = string_concat("#Stats: ", format_number_with_sign(round(((melee_att/100)-1)*100)), "%#");
-			explanation_string += "  Base: +10%#";
-			explanation_string += string_concat("  WSxSTR: ", format_number_with_sign(round((((weapon_skill/100)*(strength/20))-1)*100)), "%#");
-			explanation_string += string_concat("  EXP: ", format_number_with_sign(round((experience/1000)*100)), "%#");
+		}
 
-			melee_carrying = melee_hands_limit();
+		static melee_attack = function(weapon_slot=0){
+			var _format_sign = function(_num) {
+				_num = format_number_with_sign(round(_num));
+				return _num;
+			}
+
+			encumbered_melee=false;
+			var _melee_mod = 1;
+			var explanation_string = "";
+
+			var melee_carrying = melee_hands_limit();
 			var _wep1 = get_weapon_one_data();
 			var _wep2 = get_weapon_two_data();
 			if (!is_struct(_wep1)) then _wep1 = new EquipmentStruct({},"");
@@ -1969,7 +1972,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 							secondary_weapon=highest;
 						} else {
 							primary_weapon=highest;
-							melee_att*=0.5;
+							_melee_mod += 0.5;
 							if (primary_weapon.has_tag("flame")){
 								explanation_string+=$"Primary is Flame: -50%#"
 							} else if primary_weapon.has_tag("pistol"){
@@ -1986,29 +1989,53 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					primary_weapon=_wep2;
 				}
 			};
+
 			var basic_wep_string = $"{primary_weapon.name}: {primary_weapon.attack}#";
+			explanation_string = basic_wep_string + explanation_string;
+
+			_melee_mod += (weapon_skill / 100) + (experience / 500);
+			explanation_string += $"#Stats:#";
+			explanation_string += $"  WS: {_format_sign((weapon_skill / 100) * 100)}%#";
+			explanation_string += $"  EXP: {_format_sign((experience / 500) * 100)}%#";
+
+			if (primary_weapon.has_tag("martial") || primary_weapon.has_tag("savage")) {
+				var bonus_modifier = 0;  
+				var martial_bonus = 0;  
+				var savage_bonus = 0;  
+			
+				if (primary_weapon.has_tag("martial")) {  
+					martial_bonus = dexterity / 100;
+				}  
+				if (primary_weapon.has_tag("savage")) {  
+					savage_bonus = strength / 100;
+				}  
+			
+				bonus_modifier = martial_bonus + savage_bonus;
+				_melee_mod += bonus_modifier;
+			
+				if (martial_bonus != 0) {  
+					explanation_string += $"  DEX (Martial): {_format_sign(martial_bonus * 100)}%#";
+				}  
+				if (savage_bonus != 0) {  
+					explanation_string += $"  STR (Savage): {_format_sign(savage_bonus * 100)}%#";
+				}  
+			} else {
+				_melee_mod += (strength / 200) + (dexterity / 200);
+				explanation_string += $"  STR: {_format_sign((strength / 200) * 100)}%#";
+				explanation_string += $"  DEX: {_format_sign((dexterity / 200) * 100)}%#";  
+			}
+
 			if IsSpecialist("libs") or has_trait("warp_touched"){
-				if (primary_weapon.has_tag("force") ||_wep2.has_tag("force")){
-					var force_modifier = (((weapon_skill/100) * (psionic/10) * (intelligence/10)) + (experience/1000)+0.1);
-					primary_weapon.attack *= force_modifier;
-					basic_wep_string += $"Active Force Weapon: x{force_modifier}#  Base: 0.10#  WSxPSIxINT: x{(weapon_skill/100)*(psionic/10)*(intelligence/10)}#  EXP: x{experience/1000}#";
+				if (primary_weapon.has_tag("force")){
+					var force_modifier = (psionic * 2) * (intelligence/50);
+					_melee_mod += force_modifier / 100;
+					explanation_string += $"  PSYxINT (Force): {_format_sign(force_modifier)}%#";
 				}		
-			};
-			if (primary_weapon.has_tag("martial") ||_wep2.has_tag("martial")){
-				var martial_modifier = (((dexterity/40)) + (experience/1000)+0.1);
-				primary_weapon.attack *= martial_modifier;
-				basic_wep_string += $"Martial Prowess: x{martial_modifier}#  Base: 0.10#  DEX: {(dexterity/40)}#  EXP: {experience/1000}#";
-			};
-			if (primary_weapon.has_tag("savage") ||_wep2.has_tag("savage")){
-				var savage_modifier = (((strength/40)) + (experience/1000)+0.1);
-				primary_weapon.attack *= savage_modifier;
-				basic_wep_string += $"Innate Savagery: x{savage_modifier}#  Base: 0.10#  STR: {(strength/40)}#  EXP: {experience/1000}#";
-			};
-			explanation_string = basic_wep_string + explanation_string
+			}
 
 			if (melee_carrying[0]>melee_carrying[1]){
 				encumbered_melee=true;	
-				melee_att*=0.6;
+				_melee_mod*=0.6;
 				explanation_string+=$"Encumbered: x0.6#"
 			}
 			if (!encumbered_melee){
@@ -2018,23 +2045,24 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 				total_gear_mod+=get_mobility_data("melee_mod");
 				total_gear_mod+=_wep1.melee_mod;
 				total_gear_mod+=_wep2.melee_mod;
-				melee_att+=total_gear_mod;
-				explanation_string+=$"#Gear Mod: {(total_gear_mod/100)*100}%#";
+				total_gear_mod/=100;
+				_melee_mod += total_gear_mod;
+				explanation_string+=$"#Gear Mod: {_format_sign(total_gear_mod * 100)}%#";
 				//TODO make trait data like this more structured to be able to be moddable
 				if (has_trait("feet_floor") && mobility_item()!=""){
-					melee_att*=0.9;
+					_melee_mod*=0.9;
 					explanation_string+=$"{global.trait_list.feet_floor.display_name}: x0.9#";
 				}
 				if (primary_weapon.has_tag("fist") && has_trait("brawler")){
-					melee_att*=1.1;
+					_melee_mod*=1.1;
 					explanation_string+=$"{global.trait_list.brawler.display_name}: x1.1#";
 				}
 				if (primary_weapon.has_tag("power") && has_trait("duelist")){
-					melee_att*=1.3;
+					_melee_mod*=1.3;
 					explanation_string+=$"{global.trait_list.duelist.display_name}: x1.3#";
 				}				
 			}
-			var final_attack =  floor((melee_att/100)*primary_weapon.attack);
+			var final_attack =  floor((_melee_mod)*primary_weapon.attack);
 			if (secondary_weapon!="none" && !encumbered_melee){
 				var side_arm_data="Standard: x0.5";
 				var secondary_modifier = 0.5;
@@ -2052,12 +2080,13 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					secondary_modifier = 0.3;
 					side_arm_data="Flame: x0.3";
 				}
-				var side_arm = floor(secondary_modifier*((melee_att/100)*secondary_weapon.attack));
+				var side_arm = floor(secondary_modifier*((_melee_mod/100)*secondary_weapon.attack));
 				if (side_arm>0){
 					final_attack+=side_arm;
 					explanation_string+=$"Side Arm: +{side_arm}({side_arm_data})#";
 				}
 			}
+
 			melee_damage_data=[final_attack,explanation_string,melee_carrying,primary_weapon, secondary_weapon];
 			return melee_damage_data;
 		};

--- a/scripts/scr_marine_struct/scr_marine_struct.gml
+++ b/scripts/scr_marine_struct/scr_marine_struct.gml
@@ -2080,7 +2080,7 @@ function TTRPG_stats(faction, comp, mar, class = "marine", other_spawn_data={}) 
 					secondary_modifier = 0.3;
 					side_arm_data="Flame: x0.3";
 				}
-				var side_arm = floor(secondary_modifier*((_melee_mod/100)*secondary_weapon.attack));
+				var side_arm = floor(secondary_modifier*(_melee_mod*secondary_weapon.attack));
 				if (side_arm>0){
 					final_attack+=side_arm;
 					explanation_string+=$"Side Arm: +{side_arm} ({side_arm_data})#";


### PR DESCRIPTION
Savage & Martial tag functionality

## Summary by Sourcery

Add "martial" and "savage" weapon tags to enable custom stat scaling for melee attacks.

New Features:
- Introduce "martial" and "savage" weapon tags that scale melee attack with dexterity and strength respectively.

Tests:
- Update melee attack calculations to include new tags and modifiers.