### PR TITLE
refactor: A bit less hectic scr_start_allow

### DIFF
--- a/scripts/scr_get_item_names/scr_get_item_names.gml
+++ b/scripts/scr_get_item_names/scr_get_item_names.gml
@@ -122,15 +122,16 @@ function push_marine_gear_item_names(_item_names) {
 /// @param {array} _item_names - The list to append to.
 /// @returns {void}
 function push_marine_mobility_item_names(_item_names) {
-    var item_count = 4;
+    var item_count = 5;
     var initial_size = array_length(_item_names);
     array_resize(_item_names, initial_size + item_count);
 
     var index = initial_size;
     _item_names[@ index++] = "Bike";
     _item_names[@ index++] = "Jump Pack";
+    _item_names[@ index++] = "Heavy Weapons Pack";
     _item_names[@ index++] = "Servo-arm";
-    _item_names[@ index++] = "Servo-harness"; // 4
+    _item_names[@ index++] = "Servo-harness"; // 5
 }
 
 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -2160,10 +2160,18 @@ function scr_initialize_custom() {
 
 
 	for (i = 0; i <= 20; i++) {
-		if (role[defaults_slot, i] != "") then scr_start_allow(i, "wep1", wep1[defaults_slot, i]);
-		if (role[defaults_slot, i] != "") then scr_start_allow(i, "wep2", wep2[defaults_slot, i]);
-		if (role[defaults_slot, i] != "") then scr_start_allow(i, "mobi", mobi[defaults_slot, i]);
-		if (role[defaults_slot, i] != "") then scr_start_allow(i, "gear", gear[defaults_slot, i]);
+		if (role[defaults_slot, i] != "") {
+			scr_start_allow(i, "wep1", wep1[defaults_slot, i]);
+		}
+		if (role[defaults_slot, i] != "") {
+			scr_start_allow(i, "wep2", wep2[defaults_slot, i]);
+		}
+		if (role[defaults_slot, i] != "") {
+			scr_start_allow(i, "mobi", mobi[defaults_slot, i]);
+		}
+		if (role[defaults_slot, i] != "") {
+			scr_start_allow(i, "gear", gear[defaults_slot, i]);
+		}
 		// check for allowable starting equipment here
 	}
 

--- a/scripts/scr_start_allow/scr_start_allow.gml
+++ b/scripts/scr_start_allow/scr_start_allow.gml
@@ -1,55 +1,60 @@
 function scr_start_allow(role_id, equip_area, equipment) {
+	var _allow = false;
+	var _veteran_level = 0;
 
-	var specialist,allow;
-	specialist=0;allow=false;
-	if (role_id=2) then specialist=1;
-	if (role_id=3) then specialist=1;
-	if (role_id=4) then specialist=2;
-	if (role_id=5) then specialist=2;
-	if (role_id=6) then specialist=2;
-	if (role_id>=14) then specialist=2;
-
-
-	if (specialist>=0){
-	    if (equipment="Combat Knife") then allow=true;
-	    if (equipment="Chainsword") then allow=true;
-	    if (equipment="Chainaxe") then allow=true;
-	    if (equipment="Boarding Shield") then allow=true;
-	    if (equipment="Bolt Pistol") then allow=true;
-	    if (equipment="Bolter") then allow=true;
-	    if (equipment="Flamer") then allow=true;
-	    if (equipment="Sniper Rifle") then allow=true;
-    
-	    if (role_id!=8) and (role_id!=9) and (role_id!=4) and (role_id!=6){
-	        if (equipment="Jump Pack") then allow=true;
-	    }
-	}
-	if (specialist>=1){
-	    if (equipment="Storm Bolter") then allow=true;
-	    if (equipment="Meltagun") then allow=true;
-	    if (equipment="Power Fist") then allow=true;
-	    if (equipment="Power Sword") then allow=true;
-	    if (equipment="Power Axe") then allow=true;
-	    if (equipment="Narthecium") then allow=true;
-    
-	    if (role_id!=8) and (role_id!=9) and (role_id!=4) and (role_id!=6){
-	        if (equipment="Bike") then allow=true;
-	    }
-	}
-	if (specialist>=2){if (equip_area!="mobi") and (equip_area!="gear") then allow=true;
-	    if (equipment="Plasma Gun") then allow=false;
-	    if (role_id=14) and (equipment="Rosarius") then allow=true;
-	    if (role_id=16) and (equipment="Servo-arm") then allow=true;
-		if (role_id=16) and (equipment="Servo-harness") then allow=true;
-	    if (role_id=17) and (equipment="Psychic Hood") then allow=true;
+	if (role_id == eROLE.Dreadnought) {
+		equip_area[101, role_id] = equipment;
+		return;
 	}
 
-	if (allow=true){
-	    if (equip_area="wep1") then wep1[101,role_id]=equipment;
-	    if (equip_area="wep2") then wep2[101,role_id]=equipment;
-	    if (equip_area="gear") then gear[101,role_id]=equipment;
-	    if (equip_area="mobi") then mobi[101,role_id]=equipment;
+	if (array_contains([eROLE.Sergeant, eROLE.Veteran, eROLE.Terminator], role_id)) {
+		_veteran_level = 1;
+	} else if (array_contains([eROLE.VeteranSergeant, eROLE.Ancient, eROLE.Captain, eROLE.HonourGuard], role_id)) {
+		_veteran_level = 2;
+	} else if (array_contains([eROLE.Chaplain, eROLE.Apothecary, eROLE.Librarian, eROLE.Techmarine], role_id)) {
+		_veteran_level = 5;
 	}
 
+	var _normal_equipment = ["Combat Knife", "Chainsword", "Chainaxe", "Boarding Shield", "Bolt Pistol", "Bolter", "Flamer", "Sniper Rifle"];
+	_allow = array_contains(_normal_equipment, equipment);
 
+	if (_veteran_level > 0) {
+		var _special_equipment = ["Storm Bolter", "Meltagun", "Power Fist", "Power Sword", "Power Axe"];
+		_allow = array_contains(_special_equipment, equipment);
+	}
+
+	if (equip_area == "mobi") {
+		if (equipment == "Jump Pack" && (_veteran_level > 0 || role_id == eROLE.Assault)) {
+			if (!array_contains([eROLE.Terminator, eROLE.Dreadnought], role_id)) {
+				_allow = true;
+			}
+		} else if (equipment == "Bike" && (_veteran_level > 0 || role_id == eROLE.Assault)) {
+			if (!array_contains([eROLE.Terminator, eROLE.Dreadnought], role_id)) {
+				_allow = true;
+			}
+		} else if (equipment == "Heavy Weapons Pack" && role_id == eROLE.Devastator) {
+			_allow = true;
+		}
+	}
+
+	if (equip_area == "gear") {
+		if (_veteran_level == 5) {
+			if (role_id == eROLE.Chaplain && equipment == "Rosarius") {
+				_allow = true;
+			} else if (role_id == eROLE.Techmarine) {
+				if (array_contains(["Servo-arm", "Servo-harness"], equipment)) {
+					_allow = true;
+				}
+			} else if (role_id == eROLE.Librarian && equipment == "Psychic Hood") {
+				_allow = true;
+			} else if (role_id == eROLE.Apothecary && equipment == "Narthecium") {
+				_allow = true;
+			}
+		}
+	}
+
+	if (_allow) {
+		equip_area[101, role_id] = equipment;
+	}
+	return;
 }


### PR DESCRIPTION
- Add Heavy Weapons Pack to selection.
- Edit some other allowed equipment, as there was no visible logic to it.
- Refactor the whole file, to, hopefully, be a bit more readable.

This thing requires a full teardown, to be replaced with `scr_get_item_names` (just need to add more custom lists there) and eventually with advantage based starting equipment.