### PR TITLE
feat: Gear surplus advantages

### DIFF
--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -689,32 +689,32 @@ var all_advantages = [
             meta : ["Weapon Specialty"] 
         },
         {
-            name : "Gear Surplus: MK3 Power Armour",
+            name : "Gear Surplus: MK3 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },
         {
-            name : "Gear Surplus: MK4 Power Armour",
+            name : "Gear Surplus: MK4 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },
         {
-            name : "Gear Surplus: MK5 Power Armour",
+            name : "Gear Surplus: MK5 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },
         {
-            name : "Gear Surplus: MK6 Power Armour",
+            name : "Gear Surplus: MK6 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },
         {
-            name : "Gear Surplus: MK7 Power Armour",
+            name : "Gear Surplus: MK7 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },
         {
-            name : "Gear Surplus: MK8 Power Armour",
+            name : "Gear Surplus: MK8 Armour",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 
         },

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -724,6 +724,11 @@ var all_advantages = [
             value : 5 
         },
         {
+            name : "Gear Surplus: Plasma Weapons",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
             name : "Gear Surplus: Flamers",
             description : "Extra starting gear for your chapter, found in the Armamentarium.",
             value : 5 

--- a/objects/obj_creation/Create_0.gml
+++ b/objects/obj_creation/Create_0.gml
@@ -687,7 +687,57 @@ var all_advantages = [
             description : "Your chapter has strong ties to the Forgeworld of Ryza as a result your Techmarines are privy to the secrets of their Techpriests enhancing your Plasma and Las weaponry.",
             value : 25,
             meta : ["Weapon Specialty"] 
-        },                                                                                                                                                                             
+        },
+        {
+            name : "Gear Surplus: MK3 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: MK4 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: MK5 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: MK6 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: MK7 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: MK8 Power Armour",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: Bolters",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: Flamers",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: Power Weapons",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
+        {
+            name : "Gear Surplus: Chain Weapons",
+            description : "Extra starting gear for your chapter, found in the Armamentarium.",
+            value : 5 
+        },
     ]
 
 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3242,6 +3242,61 @@ function scr_initialize_custom() {
         scr_add_item("MK4 Maximus", irandom_range(3, 18));
 	}
 
+
+	// 5-point advantages for rounding out and satisfying 'gear buy' type wants
+	
+	if(scr_has_adv("Gear Surplus: MK3 Power Armour")){
+		scr_add_item("MK3 Iron Armour", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: MK4 Power Armour")){
+		scr_add_item("MK4 Maximus", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: MK5 Power Armour")){
+		scr_add_item("MK5 Heresy", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: MK6 Power Armour")){
+		scr_add_item("MK6 Corvus", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: MK7 Power Armour")){
+		scr_add_item("MK7 Aquila", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: MK8 Power Armour")){
+		scr_add_item("MK8 Errant", 10);
+	}
+
+	if(scr_has_adv("Gear Surplus: Power Weapons")){
+		scr_add_item("Power Sword", 4);
+		scr_add_item("Power Axe", 4);
+		scr_add_item("Power Fist", 2);
+		scr_add_item("Power Spear", 1);
+	}
+
+	if(scr_has_adv("Gear Surplus: Chain Weapons")){
+		scr_add_item("Chainsword", 5);
+		scr_add_item("Chainaxe", 5);
+		scr_add_item("Eviscerator", 3);
+	}
+
+	if(scr_has_adv("Gear Surplus: Bolters")){
+		scr_add_item("Bolt Pistol", 10);
+		scr_add_item("Bolter", 10);
+		scr_add_item("Stalker Pattern Bolter", 5);
+		scr_add_item("Heavy Bolter", 3);
+	}
+
+	if(scr_has_adv("Gear Surplus: Flamers")){
+		scr_add_item("Hand Flamer", 10);
+		scr_add_item("Flamer", 10);
+		scr_add_item("Combiflamer", 5);
+		scr_add_item("Heavy Flamer", 3);
+	}
+	
+
     gene_slaves = [];
     
 	var bloo = 0,

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3244,7 +3244,7 @@ function scr_initialize_custom() {
 
 
 	// 5-point advantages for rounding out and satisfying 'gear buy' type wants
-	
+
 	if(scr_has_adv("Gear Surplus: MK3 Power Armour")){
 		scr_add_item("MK3 Iron Armour", 10);
 	}
@@ -3294,6 +3294,11 @@ function scr_initialize_custom() {
 		scr_add_item("Flamer", 10);
 		scr_add_item("Combiflamer", 5);
 		scr_add_item("Heavy Flamer", 3);
+	}
+	
+	if(scr_has_adv("Gear Surplus: Plasma Weapons")){
+		scr_add_item("Plasma Pistol", 5);
+		scr_add_item("Plasma Gun", 5);
 	}
 	
 

--- a/scripts/scr_initialize_custom/scr_initialize_custom.gml
+++ b/scripts/scr_initialize_custom/scr_initialize_custom.gml
@@ -3245,27 +3245,27 @@ function scr_initialize_custom() {
 
 	// 5-point advantages for rounding out and satisfying 'gear buy' type wants
 
-	if(scr_has_adv("Gear Surplus: MK3 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK3 Armour")){
 		scr_add_item("MK3 Iron Armour", 10);
 	}
 
-	if(scr_has_adv("Gear Surplus: MK4 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK4 Armour")){
 		scr_add_item("MK4 Maximus", 10);
 	}
 
-	if(scr_has_adv("Gear Surplus: MK5 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK5 Armour")){
 		scr_add_item("MK5 Heresy", 10);
 	}
 
-	if(scr_has_adv("Gear Surplus: MK6 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK6 Armour")){
 		scr_add_item("MK6 Corvus", 10);
 	}
 
-	if(scr_has_adv("Gear Surplus: MK7 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK7 Armour")){
 		scr_add_item("MK7 Aquila", 10);
 	}
 
-	if(scr_has_adv("Gear Surplus: MK8 Power Armour")){
+	if(scr_has_adv("Gear Surplus: MK8 Armour")){
 		scr_add_item("MK8 Errant", 10);
 	}
 


### PR DESCRIPTION
Based on feedback from the new points balance of advantages and disadvantages, plus recurring conversations around some sort of "gear buy" system, this attempts to fill both needs by providing a way to dump small amounts extra points on surplus gear. 
Each adv is roughly 1 squad's worth of gear. 