### PR TITLE
feat: Deselect dreadnoughts on attack screen and ship load fix

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -483,7 +483,7 @@ sel_all="";
 sel_promoting=0;
 drag_square=[];
 rectangle_action = -1;
-sel_loading=0;
+sel_loading=-1;
 sel_uid=0;
 
 // ** Sets Chapter events and celebrations **

--- a/objects/obj_controller/Step_0.gml
+++ b/objects/obj_controller/Step_0.gml
@@ -462,7 +462,7 @@ if (unload>0){
     obj_ini.ship_carrying[b]-=man_size;
     sh_cargo[b]-=man_size;
     cooldown=10;
-    sel_loading=0;
+    sel_loading=-1;
     man_size=0;
     unload=0;
     with(obj_star_select){instance_destroy();}

--- a/objects/obj_drop_select/Draw_64.gml
+++ b/objects/obj_drop_select/Draw_64.gml
@@ -21,8 +21,8 @@ local_content_slate.inside_method=function(){
     var _heigth = local_content_slate.height;
      if (purge==0){
         draw_set_halign(fa_left);
-        draw_text_ext(_xx, _yy, roster.roster_local_string, -1, local_content_slate.width-30);
-        draw_text_ext(_xx+0.1, _yy+0.1, roster.roster_local_string, -1, local_content_slate.width-30);
+        draw_text_ext(_xx+15, _yy, roster.roster_local_string, -1, local_content_slate.width-30);
+        draw_text_ext(_xx+15.1, _yy+0.1, roster.roster_local_string, -1, local_content_slate.width-30);
     }     
     if (purge != DropType.RaidAttack){
         if (purge == DropType.PurgeSelect){

--- a/scripts/is_specialist/is_specialist.gml
+++ b/scripts/is_specialist/is_specialist.gml
@@ -344,7 +344,7 @@ function group_selection(group, selection_data){
 				reset_manage_arrays();
 				alll=0;              
 				cooldown=10;
-				sel_loading=0;
+				sel_loading=-1;
 				unload=0;
 				alarm[6]=7;
 				company_data={};

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -61,7 +61,7 @@ function Roster() constructor{
     }
     static update_roster = function(){
     	selected_roster = {};
-        var _allow_dreadnoughts = true;
+        var _allow_dreadnoughts = false;
     	for (var i=0;i<array_length(selected_units);i++){
     		array_push(full_roster_units, selected_units[i]);
     	}

--- a/scripts/scr_roster/scr_roster.gml
+++ b/scripts/scr_roster/scr_roster.gml
@@ -61,6 +61,7 @@ function Roster() constructor{
     }
     static update_roster = function(){
     	selected_roster = {};
+        var _allow_dreadnoughts = true;
     	for (var i=0;i<array_length(selected_units);i++){
     		array_push(full_roster_units, selected_units[i]);
     	}
@@ -75,6 +76,9 @@ function Roster() constructor{
     	for (var i=0;i<array_length(squad_buttons);i++){
     		if (squad_buttons[i].active){
     			array_push(_valid_squad_types, squad_buttons[i].squad);
+                if (squad_buttons[i].squad == "dreadnought"){
+                    _allow_dreadnoughts = true;
+                }
     		}
     	}
         var _valid_vehicles = [];
@@ -99,7 +103,14 @@ function Roster() constructor{
                 if (!array_contains(_valid_companies, _unit.company)) then continue;
 	    		if (_unit.squad_type()!= "none"){
 	    			var _valid_type = array_contains(_valid_squad_types,_unit.squad_type());
-	    		}
+	    		} else {
+                    var _armour_data = _unit.get_armour_data();
+                    if (is_struct(_armour_data)){
+                        if (_armour_data.has_tag("dreadnought")){
+                            _valid_type = _allow_dreadnoughts;
+                        }
+                    }
+                }
 
 	    		if (_unit.ship_location>-1){
 		    	 	if (array_contains(_valid_ship ,_unit.ship_location) && _valid_type){
@@ -259,6 +270,16 @@ function Roster() constructor{
                                 new_squad_button(obj_ini.squads[_unit.squad].display_name, _squad_type);
                             }
                          }
+                    } else {
+                        if (!array_contains(_squads, "dreadnought")){
+                            var _armour_data = _unit.get_armour_data();
+                            if (is_struct(_armour_data)){
+                                if (_armour_data.has_tag("dreadnought")){
+                                    array_push(_squads, "dreadnought");
+                                    new_squad_button("Dreadnought", "dreadnought");
+                                }
+                            }
+                        }                      
                     }
                 }
             }

--- a/scripts/scr_ui_manage/scr_ui_manage.gml
+++ b/scripts/scr_ui_manage/scr_ui_manage.gml
@@ -831,11 +831,11 @@ function scr_ui_manage() {
 				button.tooltip = "Press Shift L";
 				if (load_unload_possible){
 					button.alpha = 1;
-					if (sel_loading==0){
+					if (sel_loading==-1){
 						if (button.draw()){
 							load_selection();						
 						}
-					} else if (sel_loading!=0){
+					} else if (sel_loading!=-1){
 						button.label = "Unload";
 						if (button.draw()){
 							unload_selection();   // Unload - ask for planet confirmation					
@@ -928,7 +928,7 @@ function scr_ui_manage() {
 				button.label = "Set Boarder";
 				button.keystroke = (keyboard_check(vk_shift) && (keyboard_check_pressed(ord("Q"))));
 				button.tooltip = "Press Shift Q";					
-				var boarder_possible = sel_loading!=0  && man_size>0;
+				var boarder_possible = sel_loading!=-1  && man_size>0;
 				button.alpha = boarder_possible ? 1 : 0.5;
 				if (button.draw() && boarder_possible){
 					if (boarder_possible) then toggle_selection_borders();

--- a/scripts/scr_ui_refresh/scr_ui_refresh.gml
+++ b/scripts/scr_ui_refresh/scr_ui_refresh.gml
@@ -10,7 +10,7 @@ function scr_ui_refresh() {
     reset_manage_arrays();
 	
     alll = 0;
-    sel_loading = 0;
+    sel_loading = -1;
     unload = 0;
     alarm[6] = 7;
 }

--- a/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
+++ b/scripts/scr_unit_quick_find_pane/scr_unit_quick_find_pane.gml
@@ -458,7 +458,7 @@ function update_general_manage_view(){
 				company_data={};
 	        }            
 	        cooldown=10;
-	        sel_loading=0;
+	        sel_loading=-1;
 	        unload=0;
 	        alarm[6]=30;
 	    } else if (managing==-1){
@@ -563,7 +563,7 @@ function jail_selection(){
     } else if (managing==-1){
     	update_garrison_manage()
     }
-    sel_loading=0;
+    sel_loading=-1;
     unload=0;
     alarm[6]=7;		
 }


### PR DESCRIPTION
- adds button in drop select to control if player wishes dreadnoughts on battle or not
- fixes previous bug with being unable to load marines onto ships