### PR TITLE
fix: Align warp lanes with stars after game restart

### DIFF
--- a/objects/obj_controller/Create_0.gml
+++ b/objects/obj_controller/Create_0.gml
@@ -1776,7 +1776,6 @@ if (welcome_pages>=5){
     }
 }
 remov=string_length(string(temp[65])+string(temp[66])+string(temp[67])+string(temp[68])+string(temp[69]))+1;
-
 action_set_alarm(2, 0);
 
 instance_create(0,0,obj_tooltip );

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -60,7 +60,11 @@ function scr_map_scale(){
 
 function draw_warp_lanes(){
 	static routes = [];
-	if (array_length(routes)==0){
+	static current_seed = global.game_seed;
+	if (array_length(routes)==0 || current_seed!=global.game_seed){
+		current_seed=global.game_seed;
+		routes = [];
+		game_instance_id = obj_controller.id
 		var star_degrade_list = [];
 		var total_stars = instance_number(obj_star);
 		var cur_star,this_star,connection,i, check_star;

--- a/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
+++ b/scripts/scr_map_and_warp_functions/scr_map_and_warp_functions.gml
@@ -64,7 +64,6 @@ function draw_warp_lanes(){
 	if (array_length(routes)==0 || current_seed!=global.game_seed){
 		current_seed=global.game_seed;
 		routes = [];
-		game_instance_id = obj_controller.id
 		var star_degrade_list = [];
 		var total_stars = instance_number(obj_star);
 		var cur_star,this_star,connection,i, check_star;


### PR DESCRIPTION
This pull request fixes a bug where warp lanes would not line up with stars after restarting a game.
The fix involves resetting the warp lane routes when the game seed changes and rebuilding the routes based on the new seed. This ensures that the warp lanes are always consistent with the current game state.