### PR TITLE
fix: Uncommon crash from squad temporary variable

### DIFF
--- a/objects/obj_p_fleet/Alarm_6.gml
+++ b/objects/obj_p_fleet/Alarm_6.gml
@@ -10,14 +10,11 @@ with(obj_ini){scr_ini_ship_cleanup();}*/
 
 
 
-with(obj_ini){scr_ini_ship_cleanup();}
+with(obj_ini){
+    scr_ini_ship_cleanup();
+}
 
-if (capital_number<0) then capital_number=0;
-if (frigate_number<0) then frigate_number=0;
-if (escort_number<0) then escort_number=0;
-
-if (capital_uid[1]=0) and (frigate_uid[1]=0) and (escort_uid[1]=0) then instance_destroy();
-
+if (player_fleet_ship_count() == 0) then instance_destroy();
 // if ((capital_number+frigate_number+escort_number)<=0) then instance_destroy();
 
 

--- a/scripts/scr_company_view/scr_company_view.gml
+++ b/scripts/scr_company_view/scr_company_view.gml
@@ -34,6 +34,7 @@ function reset_manage_arrays() {
         ma_promote=[];
         ma_god=[];
         ma_view = [];
+        squad = [];
     }
     reset_ship_manage_arrays();
 }
@@ -73,6 +74,7 @@ function add_man_to_manage_arrays(unit){
         array_push(display_unit,unit);
         array_push(ma_god,0);
         array_push(ma_view,true);
+        array_push(squad, -1);
 	}
 }
 
@@ -118,6 +120,7 @@ function add_vehicle_to_manage_arrays(unit){
 		array_push(ma_promote,0);
 		array_push(ma_god,0);
 		array_push(ma_view,true);
+		array_push(squad, -1);
 	}
 }
 
@@ -360,6 +363,7 @@ function filter_and_sort_company(type, specific){
         var tempprom =ma_promote[a];
         var tempdis =display_unit[a];
         var tempview = ma_view[a];
+        var temp_squad = squad[a]
 
         man[a]=man[b];
         ide[a]=ide[b];
@@ -379,6 +383,7 @@ function filter_and_sort_company(type, specific){
         ma_promote[a]=ma_promote[b];
         display_unit[a] =display_unit[b];
         ma_view[a] =ma_view[b];
+        squad[a] = squad[b]
 
         man[b]=tempman;
         ide[b]=tempide;
@@ -397,7 +402,8 @@ function filter_and_sort_company(type, specific){
         ma_exp[b]= tempexp;
         ma_promote[b]= tempprom;
         display_unit[b] = tempdis;  
-        ma_view[b] = tempview;      
+        ma_view[b] = tempview;
+        squad[b] = temp_squad;
 	}
 	if (type=="stat"){
 		var swapped;

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -179,7 +179,7 @@ function scr_draw_management_unit(selected, yy=0, xx=0, draw=true){
 	    	draw_set_color(squad_colours[_squad_modulo])
 	    }
 	
-	    if (selected>0 && selected<array_length(display_unit)-1 && array_length(squad)-1<selected){
+	    if (selected>0 && selected<array_length(display_unit)-1 && array_length(squad)-1>selected){
 	    	var _cur_squad = squad[selected];
 	    	var _next_squad = squad[selected+1];
 	    	var _prev_squad = squad[selected-1];

--- a/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
+++ b/scripts/scr_draw_management_unit/scr_draw_management_unit.gml
@@ -173,14 +173,26 @@ function scr_draw_management_unit(selected, yy=0, xx=0, draw=true){
 	    // Squads
 	    var sqi="";
 	    draw_set_color(c_black);
-	    var squad_colours=[c_teal,c_red,c_green,c_orange,c_aqua,c_fuchsia,c_green,c_blue,c_fuchsia,c_maroon]
-	    var squad_modulo = squad[selected]%10;
-	    draw_set_color(squad_colours[squad_modulo])
+	    var squad_colours=[c_teal,c_red,c_green,c_orange,c_aqua,c_fuchsia,c_green,c_blue,c_fuchsia,c_maroon];
+	    if (squad[selected]!=-1){
+	    	var _squad_modulo = squad[selected]%10;
+	    	draw_set_color(squad_colours[_squad_modulo])
+	    }
 	
-	    if (selected>0 && selected<array_length(display_unit)-1){
-	        if (squad[selected]==squad[selected+1]) and (squad[selected]!=squad[selected-1]){sqi="top"}
-	        else if (squad[selected]==squad[selected+1]) and (squad[selected]==squad[selected-1]){sqi="mid"}
-	        else if (squad[selected]!=squad[selected+1]) and (squad[selected]==squad[selected-1]) then sqi="bot";
+	    if (selected>0 && selected<array_length(display_unit)-1 && array_length(squad)-1<selected){
+	    	var _cur_squad = squad[selected];
+	    	var _next_squad = squad[selected+1];
+	    	var _prev_squad = squad[selected-1];
+	        if (_cur_squad==_next_squad){
+	        	if (squad[selected]!=_prev_squad){
+	        		sqi="top";
+	        	} else {
+	        		sqi="mid"
+	        	}
+	        }
+	        else if (squad[selected]==_prev_squad){
+	        	sqi="bot";
+	        }
 	    }
 	    //TODO handle recursively with an array
 	      draw_rectangle(xx+25,yy+64,xx+25+8,yy+85,0);


### PR DESCRIPTION
- basically the "squad" temp variable in the manage variable was not being set or managed properly causing crashes, fixing this should help with the later potential feature of assigning vehicles to squads

## Summary by Sourcery

Bug Fixes:
- Fixed a crash related to the "squad" temporary variable not being correctly managed.