### PR TITLE
fix(compiler): Add missing spr_bionics_arm_2 to yyp

### DIFF
--- a/ChapterMaster.yyp
+++ b/ChapterMaster.yyp
@@ -1085,6 +1085,7 @@
     {"id":{"name":"spr_bionics_leg","path":"sprites/spr_bionics_leg/spr_bionics_leg.yy",},},
     {"id":{"name":"spr_bionics_eye","path":"sprites/spr_bionics_eye/spr_bionics_eye.yy",},},
     {"id":{"name":"spr_bionics_arm","path":"sprites/spr_bionics_arm/spr_bionics_arm.yy",},},
+    {"id":{"name":"spr_bionics_arm_2","path":"sprites/spr_bionics_arm_2/spr_bionics_arm_2.yy",},},    
     {"id":{"name":"scr_enemy_ai_c","path":"scripts/scr_enemy_ai_c/scr_enemy_ai_c.yy",},},
     {"id":{"name":"spr_ship_back_white","path":"sprites/spr_ship_back_white/spr_ship_back_white.yy",},},
     {"id":{"name":"scr_enemy_ai_d","path":"scripts/scr_enemy_ai_d/scr_enemy_ai_d.yy",},},


### PR DESCRIPTION
as title states compiler was not adding spr_bionics_arm_2 into game sprite sheet

## Summary by Sourcery

Bug Fixes:
- Fix missing `spr_bionics_arm_2` sprite from the game sprite sheet.