### PR TITLE
fix: Array error with image caching

### DIFF
--- a/scripts/scr_image/scr_image.gml
+++ b/scripts/scr_image/scr_image.gml
@@ -574,12 +574,19 @@ function scr_image_cache(path, image_id){
 	
 	if(sprite_exists(existing_sprite)){
 		drawing_sprite = existing_sprite;
-	} else {
+	} else if (image_id>-1){
 		var folders = string_replace_all(path, "/", "\\");
 		var dir = $"{working_directory}\\images\\{folders}\\{string(image_id)}.png";
 		if(file_exists(dir)){
 			drawing_sprite = sprite_add(dir,1, false,false,0,0);
-			array_set(obj_img.image_cache[$path], image_id, drawing_sprite);
+			if (image_id<array_length(obj_img.image_cache[$path])){
+				array_set(obj_img.image_cache[$path], image_id, drawing_sprite);
+			} else {
+				while (image_id<array_length(obj_img.image_cache[$path])){
+					array_push(obj_img.image_cache[$path], drawing_sprite);
+				}
+			}
+			
 		} else {
 			drawing_sprite = -1;
 			// debugl($"No directory/file found matching {dir}"); // too much noise

--- a/scripts/scr_image/scr_image.gml
+++ b/scripts/scr_image/scr_image.gml
@@ -582,7 +582,7 @@ function scr_image_cache(path, image_id){
 			if (image_id<array_length(obj_img.image_cache[$path])){
 				array_set(obj_img.image_cache[$path], image_id, drawing_sprite);
 			} else {
-				while (image_id<array_length(obj_img.image_cache[$path])){
+				while (image_id>=array_length(obj_img.image_cache[$path])){
 					array_push(obj_img.image_cache[$path], drawing_sprite);
 				}
 			}

--- a/scripts/scr_image/scr_image.gml
+++ b/scripts/scr_image/scr_image.gml
@@ -579,13 +579,10 @@ function scr_image_cache(path, image_id){
 		var dir = $"{working_directory}\\images\\{folders}\\{string(image_id)}.png";
 		if(file_exists(dir)){
 			drawing_sprite = sprite_add(dir,1, false,false,0,0);
-			if (image_id<array_length(obj_img.image_cache[$path])){
-				array_set(obj_img.image_cache[$path], image_id, drawing_sprite);
-			} else {
-				while (image_id>=array_length(obj_img.image_cache[$path])){
-					array_push(obj_img.image_cache[$path], drawing_sprite);
-				}
+			if (image_id >= array_length(obj_img.image_cache[$path])) {
+				array_resize(obj_img.image_cache[$path], image_id + 1);
 			}
+			array_set(obj_img.image_cache[$path], image_id, drawing_sprite);
 			
 		} else {
 			drawing_sprite = -1;


### PR DESCRIPTION
solves this https://discord.com/channels/714022226810372107/1320602548494794782

## Summary by Sourcery

Bug Fixes:
- Fix an array out-of-bounds error that occurred when caching images with an ID larger than the current size of the cache.