### PR TITLE
fix: Attempted fix for crash when image id 0

### DIFF
--- a/scripts/scr_image/scr_image.gml
+++ b/scripts/scr_image/scr_image.gml
@@ -555,11 +555,10 @@ function scr_image_cache(path, image_id) {
         var drawing_sprite;
         var cache_arr_exists = struct_exists(obj_img.image_cache, path);
         if (!cache_arr_exists) {
-            var empty_arr = array_create(100, -1);
-            variable_struct_set(obj_img.image_cache, path, empty_arr);
+            variable_struct_set(obj_img.image_cache, path, array_create(100, -1));
         }
         // Start with 100 slots but allow it to expand if needed
-        if (cache_arr_exists && image_id > 100) {
+        if (image_id > 100) {
             for (var i = 100; i <= image_id; i++) {
                 array_push(obj_img.image_cache[$ path], -1);
             }


### PR DESCRIPTION
unsure if this will work for sure, looks like array_create on line 557 was being passed-by-reference and then garbage collected

## Description of changes
- remove unnecessary checks which may prevent resizing 
- removed explicit local var declaration to prevent garbage collection
## Reasons for changes
- attempted crashfix
## Related links
- https://discord.com/channels/714022226810372107/1328975308140974183
## How have you tested your changes?
no testing, away from home pc when making this edit
- [ ] Compile
- [ ] New game
- [ ] Next turn
- [ ] Space Travel
- [ ] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
